### PR TITLE
Add Codex runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ npm-debug.log*
 
 # Claude Code local state
 .claude/
+# Runtime-agnostic local state (Codex / dual-runtime)
+.pokayokay/
 .mcp.json
 
 docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to pokayokay are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Codex Runtime Support** — Pokayokay can now be installed/configured for Codex alongside existing Claude Code support
+  - Added Codex plugin manifest, ohno MCP config, and hook config while preserving the existing Claude plugin manifest
+  - Setup wizard detects Claude Code, Codex, or both and configures the selected runtimes
+  - Added Codex `config.toml` MCP helpers for `~/.codex/config.toml`
+  - Hook bridge now normalizes Claude-style and Codex-style hook payloads before routing to existing handlers
+  - Added focused compatibility tests for Codex plugin files, CLI dual-runtime helpers, and hook normalization
+
+## [0.22.0] - 2026-04-05
+
+### Added
+- **Pre-Implementation Design Review** — New `yokay-design-reviewer` agent validates implementation approach against codebase patterns and design skills before the implementer starts coding
+  - Read-only, skill-aware agent that searches for and consults relevant design skills
+  - New `design-review-prompt.md` dispatch template
+  - Implementer receives pre-validated approach via `{APPROACH}` template variable
+  - New `NEEDS_REDESIGN` escalation status when approach is infeasible
+  - Quality reviewer expanded with design compliance post-check
+  - Pipeline: Brainstorm? → **Design Review (new)** → Implementer → Spec Review → Quality Review (+design)
+  - Agent count: 13 → 14
+- **Agent Color Coding** — All 14 agents now have `color` frontmatter for UI identification
+  - Magenta (creative): brainstormer, design-reviewer
+  - Cyan (planning): planner, explorer
+  - Green (execution): implementer, fixer, spike-runner, test-runner, browser-verifier
+  - Yellow (validation): spec-reviewer, quality-reviewer, auditor
+  - Blue (review): reviewer
+  - Red (security): security-scanner
+- **Talos Integration Fields** — Planner now outputs `packages_touched` and `strategy` per task
+  - `packages_touched` enables conflict-aware parallel batching in Talos
+  - `strategy` (tdd/direct) enables per-task override for mixed frontend/backend slices
+
 ## [0.19.0] - 2026-03-24
 
 ### Changed
@@ -27,6 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Anti-pattern: "Horizontal layer tasks" added to both `planning/anti-patterns.md` and `work-session/anti-patterns.md`
 - Anti-pattern: "File-existence-only tests" added to `work-session/anti-patterns.md`
+
+### Docs
+- Audited and fixed documentation accuracy across 15 files: corrected `--plugin-dir` paths, updated hook flow diagrams with 7 missing actions from v0.13-v0.16, fixed npm scope, removed stale fork-test artifacts from NO-GO `context:fork` spike
 
 ## [0.18.1] - 2026-03-18
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # pokayokay
 
-**AI-assisted development orchestration** - A Claude Code plugin that orchestrates AI-assisted development sessions with configurable human oversight, bridging the gap between hands-on control and full automation through skills, hooks, agents, and integration with ohno for task management.
+**AI-assisted development orchestration** - A Claude Code and Codex plugin that orchestrates AI-assisted development sessions with configurable human oversight, bridging the gap between hands-on control and full automation through skills, hooks, agents, and integration with ohno for task management.
 
 ## Features
 
@@ -22,7 +22,7 @@
 
 ## Prerequisites
 
-- **Claude Code** v1.0.0 or later
+- **Claude Code** v1.0.0 or later, or **Codex**
 - **Node.js** v18 or later (for ohno CLI)
 - **Git** (for version control integration)
 
@@ -35,7 +35,7 @@ npx pokayokay
 ```
 
 This interactive wizard will:
-1. Install the pokayokay Claude Code plugin
+1. Install the pokayokay plugin for Claude Code, Codex, or both
 2. Configure the ohno MCP server
 3. Initialize ohno in your project
 4. Optionally set up kaizen integration
@@ -46,6 +46,8 @@ Run `npx pokayokay doctor` anytime to verify your installation.
 
 <details>
 <summary>Click to expand manual steps</summary>
+
+Claude Code:
 
 ```bash
 # 1. Add the marketplace (one-time setup)
@@ -62,9 +64,19 @@ Or from inside Claude Code REPL:
 /plugin install pokayokay@srstomp-pokayokay
 ```
 
+Codex:
+
+```bash
+# From this repository, validate/load the Codex plugin from plugins/pokayokay.
+# The setup wizard can also create a local Codex marketplace entry.
+npx pokayokay
+```
+
 #### Required: ohno MCP Server
 
-Add to your MCP configuration (`~/.claude/settings.json`):
+Add to your MCP configuration.
+
+Claude Code (`~/.claude/settings.json`):
 
 ```json
 {
@@ -75,6 +87,14 @@ Add to your MCP configuration (`~/.claude/settings.json`):
     }
   }
 }
+```
+
+Codex (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.ohno]
+command = "npx"
+args = ["@stevestomp/ohno-mcp"]
 ```
 
 #### Initialize ohno
@@ -91,7 +111,7 @@ npx @stevestomp/ohno-cli init
 # 1. Run setup wizard (if not done already)
 npx pokayokay
 
-# 2. Restart Claude Code to activate MCP server
+# 2. Restart your configured AI runtime to activate MCP server
 
 # 3. Plan from a PRD
 /pokayokay:plan docs/prd.md
@@ -262,7 +282,7 @@ Loads tasks with saved WIP data from ohno, skips brainstorming for resumed tasks
 
 ### Headless Session Chaining
 
-When context fills during auto-mode work, sessions can automatically chain — finishing gracefully and spawning a new session that resumes from WIP. This is configured in `.claude/pokayokay.json`, not via a command flag:
+When context fills during auto-mode work, sessions can automatically chain — finishing gracefully and spawning a new session that resumes from WIP. This is configured in `.pokayokay/config.json`, with `.claude/pokayokay.json` still supported for existing Claude Code projects:
 
 ```json
 {

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,7 +9,7 @@ npx pokayokay
 ```
 
 This interactive wizard will:
-1. Install the pokayokay Claude Code plugin
+1. Install the pokayokay plugin for Claude Code, Codex, or both
 2. Configure the ohno MCP server
 3. Initialize ohno in your project
 4. Optionally set up kaizen integration
@@ -25,7 +25,7 @@ This interactive wizard will:
 ## What Gets Configured
 
 ### pokayokay Plugin
-The Claude Code plugin that provides orchestration commands:
+The Claude Code/Codex plugin that provides orchestration commands:
 - `/pokayokay:plan` - Plan from PRD
 - `/pokayokay:work` - Start work sessions
 - `/pokayokay:audit` - Audit completeness
@@ -47,11 +47,14 @@ Failure pattern capture and learning:
 If you prefer manual setup:
 
 ```bash
-# 1. Install plugin
+# 1. Install plugin for Claude Code
 claude plugin marketplace add srstomp/pokayokay
 claude plugin install pokayokay@srstomp-pokayokay
 
-# 2. Add to ~/.claude/settings.json
+# 2. Or configure Codex from this repository
+npx pokayokay
+
+# 3. Add to ~/.claude/settings.json for Claude Code
 {
   "mcpServers": {
     "ohno": {
@@ -61,14 +64,19 @@ claude plugin install pokayokay@srstomp-pokayokay
   }
 }
 
-# 3. Initialize ohno
+# 4. Or add to ~/.codex/config.toml for Codex
+[mcp_servers.ohno]
+command = "npx"
+args = ["@stevestomp/ohno-mcp"]
+
+# 5. Initialize ohno
 npx @stevestomp/ohno-cli init
 ```
 
 ## Requirements
 
 - Node.js 18+
-- Claude Code CLI
+- Claude Code CLI or Codex
 
 ## License
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,6 +15,7 @@
   ],
   "keywords": [
     "claude-code",
+    "codex",
     "setup",
     "wizard",
     "cli",

--- a/cli/src/detect.js
+++ b/cli/src/detect.js
@@ -1,15 +1,15 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { getClaudeConfigPath, getPlatformName } from './utils/platform.js';
-import { readClaudeConfig, isMcpConfigured } from './utils/config.js';
-import { commandExists, getClaudeVersion } from './utils/execute.js';
+import { getClaudeConfigPath, getCodexConfigPath, getPlatformName } from './utils/platform.js';
+import { readClaudeConfig, readCodexConfig, isMcpConfigured } from './utils/config.js';
+import { commandExists, getClaudeVersion, getCodexVersion } from './utils/execute.js';
 
 /**
  * Check if pokayokay plugin is installed by checking disk paths
  * @returns {object} { installed: boolean, scope: 'global'|'local'|null }
  */
-function detectPluginInstalled() {
+function detectClaudePluginInstalled() {
   // Check global paths
   const globalPaths = [
     join(homedir(), '.claude', 'plugins', 'installed', 'pokayokay'),
@@ -25,6 +25,29 @@ function detectPluginInstalled() {
   // Check project-local
   if (existsSync('.claude/plugins/pokayokay')) {
     return { installed: true, scope: 'local', path: '.claude/plugins/pokayokay' };
+  }
+
+  return { installed: false, scope: null, path: null };
+}
+
+/**
+ * Check if pokayokay is available to Codex through common local plugin paths.
+ * @returns {object} { installed: boolean, scope: 'global'|'local'|null }
+ */
+function detectCodexPluginInstalled() {
+  const globalPaths = [
+    join(homedir(), '.codex', 'plugins', 'installed', 'pokayokay'),
+    join(homedir(), 'plugins', 'pokayokay', '.codex-plugin', 'plugin.json')
+  ];
+
+  for (const p of globalPaths) {
+    if (existsSync(p)) {
+      return { installed: true, scope: 'global', path: p };
+    }
+  }
+
+  if (existsSync('plugins/pokayokay/.codex-plugin/plugin.json')) {
+    return { installed: true, scope: 'local', path: 'plugins/pokayokay' };
   }
 
   return { installed: false, scope: null, path: null };
@@ -61,6 +84,43 @@ function detectMcpConfig(serverName) {
 }
 
 /**
+ * Check Codex MCP configuration.
+ * @param {string} serverName - MCP server name to check
+ * @returns {object} { configured: boolean, scope: 'global'|'local'|null }
+ */
+function detectCodexMcpConfig(serverName) {
+  const globalConfig = readCodexConfig(getCodexConfigPath());
+  if (isMcpConfigured(globalConfig, serverName)) {
+    return { configured: true, scope: 'global' };
+  }
+
+  if (existsSync('.mcp.json')) {
+    try {
+      const localConfig = JSON.parse(readFileSync('.mcp.json', 'utf-8'));
+      if (isMcpConfigured(localConfig, serverName)) {
+        return { configured: true, scope: 'local' };
+      }
+    } catch {
+      // Invalid JSON, treat as not configured
+    }
+  }
+
+  return { configured: false, scope: null };
+}
+
+/**
+ * Select default install targets based on detected runtimes.
+ * @param {object} env - Runtime detection subset
+ * @returns {string[]} Runtime ids
+ */
+export function selectDefaultInstallTargets(env) {
+  return [
+    env.claudeInstalled ? 'claude' : null,
+    env.codexInstalled ? 'codex' : null,
+  ].filter(Boolean);
+}
+
+/**
  * Check if kaizen CLI is installed and initialized
  * Checks PATH, GOPATH/bin, and ~/go/bin
  * @returns {Promise<object>} { cliInstalled: boolean, initialized: boolean, scope: 'global'|'local'|null }
@@ -94,12 +154,18 @@ async function detectKaizen() {
 export async function detectEnvironment() {
   const configPath = getClaudeConfigPath();
   const config = readClaudeConfig(configPath);
+  const codexConfigPath = getCodexConfigPath();
+  const codexConfig = readCodexConfig(codexConfigPath);
 
   const claudeInstalled = await commandExists('claude');
   const claudeVersion = claudeInstalled ? await getClaudeVersion() : null;
+  const codexInstalled = await commandExists('codex');
+  const codexVersion = codexInstalled ? await getCodexVersion() : null;
 
-  const pluginStatus = detectPluginInstalled();
+  const pluginStatus = detectClaudePluginInstalled();
+  const codexPluginStatus = detectCodexPluginInstalled();
   const mcpStatus = detectMcpConfig('ohno');
+  const codexMcpStatus = detectCodexMcpConfig('ohno');
   const kaizenStatus = await detectKaizen();
 
   return {
@@ -112,15 +178,27 @@ export async function detectEnvironment() {
     claudeInstalled,
     claudeVersion,
     claudeConfigPath: configPath,
+    codexInstalled,
+    codexVersion,
+    codexConfigPath,
 
-    // Plugin status
+    // Claude plugin status
     pluginInstalled: pluginStatus.installed,
     pluginScope: pluginStatus.scope,
     pluginPath: pluginStatus.path,
 
-    // MCP status
+    // Codex plugin status
+    codexPluginInstalled: codexPluginStatus.installed,
+    codexPluginScope: codexPluginStatus.scope,
+    codexPluginPath: codexPluginStatus.path,
+
+    // Claude MCP status
     mcpConfigured: mcpStatus.configured,
     mcpScope: mcpStatus.scope,
+
+    // Codex MCP status
+    codexMcpConfigured: codexMcpStatus.configured,
+    codexMcpScope: codexMcpStatus.scope,
 
     // ohno init
     ohnoInitialized: existsSync('.ohno'),
@@ -131,6 +209,8 @@ export async function detectEnvironment() {
     kaizenScope: kaizenStatus.scope,
 
     // Raw config for later use
-    config
+    config,
+    codexConfig,
+    defaultInstallTargets: selectDefaultInstallTargets({ claudeInstalled, codexInstalled })
   };
 }

--- a/cli/src/detect.js
+++ b/cli/src/detect.js
@@ -31,7 +31,8 @@ function detectClaudePluginInstalled() {
 }
 
 /**
- * Check if pokayokay is available to Codex through common local plugin paths.
+ * Check if pokayokay is available to Codex through common local plugin paths
+ * or the local marketplace file written by `installPlugin()`.
  * @returns {object} { installed: boolean, scope: 'global'|'local'|null }
  */
 function detectCodexPluginInstalled() {
@@ -43,6 +44,22 @@ function detectCodexPluginInstalled() {
   for (const p of globalPaths) {
     if (existsSync(p)) {
       return { installed: true, scope: 'global', path: p };
+    }
+  }
+
+  // Setup writes a marketplace entry to ~/.agents/plugins/marketplace.json.
+  // Treat presence of the pokayokay entry as "installed" so doctor/setup
+  // do not repeatedly report Codex as not installed after a successful run.
+  const marketplacePath = join(homedir(), '.agents', 'plugins', 'marketplace.json');
+  if (existsSync(marketplacePath)) {
+    try {
+      const data = JSON.parse(readFileSync(marketplacePath, 'utf-8'));
+      const plugins = Array.isArray(data?.plugins) ? data.plugins : [];
+      if (plugins.some((p) => p && p.name === 'pokayokay')) {
+        return { installed: true, scope: 'global', path: marketplacePath };
+      }
+    } catch {
+      // Invalid JSON — ignore and continue with the other detectors.
     }
   }
 

--- a/cli/src/doctor.js
+++ b/cli/src/doctor.js
@@ -18,18 +18,30 @@ export async function doctor() {
   const env = await detectEnvironment();
   let requiredGood = true;
 
-  // Claude Code
+  // Supported runtimes
   if (env.claudeInstalled) {
     console.log(chalk.green(`  ✓ Claude Code installed (v${env.claudeVersion || 'unknown'})`));
   } else {
-    console.log(chalk.red('  ✗ Claude Code not installed'));
+    console.log(chalk.dim('  ○ Claude Code not installed'));
     console.log(chalk.dim('    Install from: https://claude.ai/code'));
+  }
+
+  if (env.codexInstalled) {
+    console.log(chalk.green(`  ✓ Codex installed (v${env.codexVersion || 'unknown'})`));
+  } else {
+    console.log(chalk.dim('  ○ Codex not installed'));
+  }
+
+  if (!env.claudeInstalled && !env.codexInstalled) {
     requiredGood = false;
   }
 
   // Plugin
-  if (env.pluginInstalled) {
-    console.log(chalk.green(`  ✓ pokayokay plugin active (${env.pluginScope})`));
+  if (env.pluginInstalled || env.codexPluginInstalled) {
+    const scopes = [];
+    if (env.pluginInstalled) scopes.push(`Claude ${env.pluginScope}`);
+    if (env.codexPluginInstalled) scopes.push(`Codex ${env.codexPluginScope}`);
+    console.log(chalk.green(`  ✓ pokayokay plugin active (${scopes.join(', ')})`));
   } else {
     console.log(chalk.red('  ✗ pokayokay plugin not installed'));
     console.log(chalk.dim('    Run: npx pokayokay'));
@@ -37,8 +49,11 @@ export async function doctor() {
   }
 
   // MCP
-  if (env.mcpConfigured) {
-    console.log(chalk.green(`  ✓ ohno MCP server configured (${env.mcpScope})`));
+  if (env.mcpConfigured || env.codexMcpConfigured) {
+    const scopes = [];
+    if (env.mcpConfigured) scopes.push(`Claude ${env.mcpScope}`);
+    if (env.codexMcpConfigured) scopes.push(`Codex ${env.codexMcpScope}`);
+    console.log(chalk.green(`  ✓ ohno MCP server configured (${scopes.join(', ')})`));
   } else {
     console.log(chalk.red('  ✗ ohno MCP server not configured'));
     console.log(chalk.dim('    Run: npx pokayokay'));

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import prompts from 'prompts';
 import { detectEnvironment } from './detect.js';
 import { installPlugin } from './steps/plugin.js';
 import { configureMcp } from './steps/mcp.js';
@@ -23,7 +24,13 @@ function printEnvironment(env) {
   if (env.claudeInstalled) {
     console.log(chalk.green(`  ✓ Claude Code: v${env.claudeVersion || 'installed'}`));
   } else {
-    console.log(chalk.red('  ✗ Claude Code: not found'));
+    console.log(chalk.dim('  ○ Claude Code: not found'));
+  }
+
+  if (env.codexInstalled) {
+    console.log(chalk.green(`  ✓ Codex: v${env.codexVersion || 'installed'}`));
+  } else {
+    console.log(chalk.dim('  ○ Codex: not found'));
   }
 
   console.log(chalk.green(`  ✓ Node.js: ${env.nodeVersion}`));
@@ -32,7 +39,7 @@ function printEnvironment(env) {
 /**
  * Print completion summary
  * @param {object} results - Step results with scopes
- * @param {boolean} needsRestart - Whether Claude Code needs restart
+ * @param {boolean} needsRestart - Whether configured runtimes need restart
  */
 function printSummary(results, needsRestart) {
   console.log(chalk.bold.green('\n  ✓ Setup complete!\n'));
@@ -84,12 +91,12 @@ function printSummary(results, needsRestart) {
 
   if (needsRestart) {
     console.log(chalk.yellow('\n  ⚠ Action required:'));
-    console.log('    Restart Claude Code to activate MCP server');
+    console.log('    Restart configured AI runtimes to activate MCP server');
   }
 
   console.log(chalk.bold('\n  Next steps:'));
   if (needsRestart) {
-    console.log("    1. Restart Claude Code");
+    console.log("    1. Restart your configured AI runtime");
     console.log("    2. Run '/pokayokay:plan docs/prd.md' to plan from a PRD");
     console.log("    3. Run '/pokayokay:work' to start a work session");
   } else {
@@ -98,6 +105,28 @@ function printSummary(results, needsRestart) {
   }
 
   console.log(chalk.dim("\n  Run 'npx pokayokay doctor' to verify installation anytime.\n"));
+}
+
+async function chooseInstallTargets(env) {
+  const availableTargets = [
+    env.claudeInstalled ? { title: 'Claude Code', value: 'claude' } : null,
+    env.codexInstalled ? { title: 'Codex', value: 'codex' } : null,
+  ].filter(Boolean);
+
+  if (availableTargets.length <= 1) {
+    return availableTargets.map((target) => target.value);
+  }
+
+  const { targets } = await prompts({
+    type: 'multiselect',
+    name: 'targets',
+    message: 'Install/configure Pokayokay for which runtimes?',
+    choices: availableTargets,
+    min: 1,
+    initial: [0, 1],
+  });
+
+  return targets && targets.length ? targets : env.defaultInstallTargets;
 }
 
 /**
@@ -111,11 +140,13 @@ export async function main() {
   printEnvironment(env);
 
   // Check prerequisites
-  if (!env.claudeInstalled) {
-    console.log(chalk.red('\n  Claude Code is required but not installed.'));
-    console.log('  Install from: https://claude.ai/code\n');
+  if (!env.claudeInstalled && !env.codexInstalled) {
+    console.log(chalk.red('\n  Claude Code or Codex is required but neither was found.'));
+    console.log('  Install at least one supported AI runtime, then re-run setup.\n');
     process.exit(1);
   }
+
+  env.installTargets = await chooseInstallTargets(env);
 
   // Run steps and track results with scopes
   const pluginResult = await installPlugin(env);

--- a/cli/src/steps/mcp.js
+++ b/cli/src/steps/mcp.js
@@ -1,7 +1,11 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import prompts from 'prompts';
 import chalk from 'chalk';
-import { readClaudeConfig, writeClaudeConfig } from '../utils/config.js';
+import {
+  readClaudeConfig,
+  writeClaudeConfig,
+  writeCodexMcpServer,
+} from '../utils/config.js';
 
 /**
  * Read .mcp.json or return empty object
@@ -36,9 +40,16 @@ export async function configureMcp(env) {
   console.log('  ohno tracks tasks, dependencies, and progress via MCP.');
   console.log('  Required for /work and /plan commands.\n');
 
-  if (env.mcpConfigured) {
-    console.log(chalk.green(`  ✓ ohno MCP server already configured (${env.mcpScope})`));
-    return { success: true, scope: env.mcpScope, needsRestart: false };
+  const targets = env.installTargets || env.defaultInstallTargets || ['claude'];
+  const needsClaude = targets.includes('claude');
+  const needsCodex = targets.includes('codex');
+
+  if ((!needsClaude || env.mcpConfigured) && (!needsCodex || env.codexMcpConfigured)) {
+    const scopes = [];
+    if (needsClaude) scopes.push(`Claude ${env.mcpScope}`);
+    if (needsCodex) scopes.push(`Codex ${env.codexMcpScope}`);
+    console.log(chalk.green(`  ✓ ohno MCP server already configured (${scopes.join(', ')})`));
+    return { success: true, scope: scopes.join(', '), needsRestart: false };
   }
 
   const { scope } = await prompts({
@@ -64,7 +75,9 @@ export async function configureMcp(env) {
   };
 
   try {
-    if (scope === 'global') {
+    const configuredScopes = [];
+
+    if (needsClaude && !env.mcpConfigured && scope === 'global') {
       // Add to global Claude config
       const config = readClaudeConfig(env.claudeConfigPath);
       config.mcpServers = config.mcpServers || {};
@@ -74,17 +87,34 @@ export async function configureMcp(env) {
       if (backupPath) {
         console.log(chalk.dim(`  Backed up config to ${backupPath}`));
       }
-    } else {
+      configuredScopes.push('Claude global');
+    } else if (needsClaude && !env.mcpConfigured) {
       // Add to project-local .mcp.json
       const config = readLocalMcpConfig();
       config.mcpServers = config.mcpServers || {};
       config.mcpServers.ohno = mcpEntry;
       writeLocalMcpConfig(config);
+      configuredScopes.push('Claude local');
     }
 
-    console.log(chalk.green(`  ✓ MCP server configured (${scope})`));
-    console.log(chalk.yellow('  ⚠ Restart Claude Code to activate'));
-    return { success: true, scope, needsRestart: true };
+    if (needsCodex && !env.codexMcpConfigured && scope === 'global') {
+      const backupPath = writeCodexMcpServer(env.codexConfigPath, 'ohno', mcpEntry);
+      if (backupPath) {
+        console.log(chalk.dim(`  Backed up Codex config to ${backupPath}`));
+      }
+      configuredScopes.push('Codex global');
+    } else if (needsCodex && !env.codexMcpConfigured) {
+      const config = readLocalMcpConfig();
+      config.mcpServers = config.mcpServers || {};
+      config.mcpServers.ohno = mcpEntry;
+      writeLocalMcpConfig(config);
+      configuredScopes.push('Codex local');
+    }
+
+    const resultScope = configuredScopes.join(', ') || scope;
+    console.log(chalk.green(`  ✓ MCP server configured (${resultScope})`));
+    console.log(chalk.yellow('  ⚠ Restart configured AI runtimes to activate MCP server'));
+    return { success: true, scope: resultScope, needsRestart: true };
   } catch (err) {
     console.log(chalk.red(`  ✗ Failed: ${err.message}`));
     return { success: false, scope: null, needsRestart: false };

--- a/cli/src/steps/plugin.js
+++ b/cli/src/steps/plugin.js
@@ -1,6 +1,56 @@
 import prompts from 'prompts';
 import chalk from 'chalk';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { execute } from '../utils/execute.js';
+
+function ensureCodexMarketplaceEntry() {
+  const agentsDir = join(homedir(), '.agents', 'plugins');
+  const marketplacePath = join(agentsDir, 'marketplace.json');
+  mkdirSync(agentsDir, { recursive: true });
+
+  let marketplace = {
+    name: 'pokayokay-local',
+    interface: {
+      displayName: 'Pokayokay Local'
+    },
+    plugins: []
+  };
+
+  if (existsSync(marketplacePath)) {
+    try {
+      marketplace = JSON.parse(readFileSync(marketplacePath, 'utf-8'));
+      marketplace.plugins = marketplace.plugins || [];
+      marketplace.interface = marketplace.interface || { displayName: 'Local Plugins' };
+    } catch {
+      // Replace invalid marketplace JSON with a valid local marketplace.
+    }
+  }
+
+  const entry = {
+    name: 'pokayokay',
+    source: {
+      source: 'local',
+      path: './plugins/pokayokay'
+    },
+    policy: {
+      installation: 'AVAILABLE',
+      authentication: 'ON_INSTALL'
+    },
+    category: 'Coding'
+  };
+
+  const index = marketplace.plugins.findIndex((plugin) => plugin.name === 'pokayokay');
+  if (index >= 0) {
+    marketplace.plugins[index] = entry;
+  } else {
+    marketplace.plugins.push(entry);
+  }
+
+  writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + '\n');
+  return marketplacePath;
+}
 
 /**
  * Step 1: Install pokayokay plugin
@@ -8,18 +58,25 @@ import { execute } from '../utils/execute.js';
  * @returns {Promise<{success: boolean, scope: string|null}>}
  */
 export async function installPlugin(env) {
-  console.log(chalk.bold('\nStep 1/4: Claude Code Plugin'));
+  console.log(chalk.bold('\nStep 1/4: AI Runtime Plugin'));
   console.log('  The pokayokay plugin provides orchestration commands like /work, /plan, /audit.\n');
 
-  if (env.pluginInstalled) {
-    console.log(chalk.green(`  ✓ pokayokay plugin already installed (${env.pluginScope})`));
-    return { success: true, scope: env.pluginScope };
+  const targets = env.installTargets || env.defaultInstallTargets || ['claude'];
+  const needsClaude = targets.includes('claude');
+  const needsCodex = targets.includes('codex');
+
+  if ((!needsClaude || env.pluginInstalled) && (!needsCodex || env.codexPluginInstalled)) {
+    const scopes = [];
+    if (needsClaude) scopes.push(`Claude ${env.pluginScope}`);
+    if (needsCodex) scopes.push(`Codex ${env.codexPluginScope}`);
+    console.log(chalk.green(`  ✓ pokayokay plugin already installed (${scopes.join(', ')})`));
+    return { success: true, scope: scopes.join(', ') };
   }
 
   const { scope } = await prompts({
     type: 'select',
     name: 'scope',
-    message: 'Install pokayokay plugin?',
+    message: `Install pokayokay plugin for ${targets.join(' + ')}?`,
     choices: [
       { title: 'Global (recommended)', description: 'Available in all projects', value: 'global' },
       { title: 'Project-local', description: 'Only this project', value: 'local' },
@@ -33,30 +90,43 @@ export async function installPlugin(env) {
     return { success: false, scope: null };
   }
 
-  // Add marketplace (ignore errors if already added)
-  console.log('  Adding marketplace...');
-  const addResult = await execute('claude', ['plugin', 'marketplace', 'add', 'srstomp/pokayokay']);
-  if (addResult.success) {
-    console.log(chalk.green('  ✓ Marketplace added'));
-  } else if (addResult.stderr.includes('already')) {
-    console.log(chalk.dim('  Marketplace already added'));
-  } else {
-    console.log(chalk.red(`  ✗ Failed to add marketplace: ${addResult.stderr}`));
-    return { success: false, scope: null };
+  const installedScopes = [];
+
+  if (needsClaude && !env.pluginInstalled) {
+    // Add marketplace (ignore errors if already added)
+    console.log('  Adding Claude marketplace...');
+    const addResult = await execute('claude', ['plugin', 'marketplace', 'add', 'srstomp/pokayokay']);
+    if (addResult.success) {
+      console.log(chalk.green('  ✓ Claude marketplace added'));
+    } else if (addResult.stderr.includes('already')) {
+      console.log(chalk.dim('  Claude marketplace already added'));
+    } else {
+      console.log(chalk.red(`  ✗ Failed to add Claude marketplace: ${addResult.stderr}`));
+      return { success: false, scope: null };
+    }
+
+    // Install plugin with scope
+    console.log(`  Installing Claude plugin (${scope})...`);
+    const installArgs = scope === 'local'
+      ? ['plugin', 'install', '--local', 'pokayokay@srstomp-pokayokay']
+      : ['plugin', 'install', 'pokayokay@srstomp-pokayokay'];
+
+    const installResult = await execute('claude', installArgs);
+    if (!installResult.success) {
+      console.log(chalk.red(`  ✗ Failed to install Claude plugin: ${installResult.stderr}`));
+      return { success: false, scope: null };
+    }
+
+    installedScopes.push(`Claude ${scope}`);
   }
 
-  // Install plugin with scope
-  console.log(`  Installing plugin (${scope})...`);
-  const installArgs = scope === 'local'
-    ? ['plugin', 'install', '--local', 'pokayokay@srstomp-pokayokay']
-    : ['plugin', 'install', 'pokayokay@srstomp-pokayokay'];
-
-  const installResult = await execute('claude', installArgs);
-  if (!installResult.success) {
-    console.log(chalk.red(`  ✗ Failed to install plugin: ${installResult.stderr}`));
-    return { success: false, scope: null };
+  if (needsCodex && !env.codexPluginInstalled) {
+    const marketplacePath = ensureCodexMarketplaceEntry();
+    console.log(chalk.green(`  ✓ Codex marketplace entry written to ${marketplacePath}`));
+    installedScopes.push('Codex marketplace');
   }
 
-  console.log(chalk.green(`  ✓ Plugin installed (${scope})`));
-  return { success: true, scope };
+  const resultScope = installedScopes.join(', ') || scope;
+  console.log(chalk.green(`  ✓ Plugin installed (${resultScope})`));
+  return { success: true, scope: resultScope };
 }

--- a/cli/src/steps/plugin.js
+++ b/cli/src/steps/plugin.js
@@ -2,7 +2,7 @@ import prompts from 'prompts';
 import chalk from 'chalk';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execute } from '../utils/execute.js';
 
 function ensureCodexMarketplaceEntry() {
@@ -28,11 +28,16 @@ function ensureCodexMarketplaceEntry() {
     }
   }
 
+  // The marketplace file lives under the user home directory, so a relative
+  // plugin path would be ambiguous. Resolve to an absolute path against the
+  // current working directory (the project root the user ran setup from).
+  const pluginPath = resolve(process.cwd(), 'plugins', 'pokayokay');
+
   const entry = {
     name: 'pokayokay',
     source: {
       source: 'local',
-      path: './plugins/pokayokay'
+      path: pluginPath
     },
     policy: {
       installation: 'AVAILABLE',
@@ -73,26 +78,49 @@ export async function installPlugin(env) {
     return { success: true, scope: scopes.join(', ') };
   }
 
-  const { scope } = await prompts({
-    type: 'select',
-    name: 'scope',
-    message: `Install pokayokay plugin for ${targets.join(' + ')}?`,
-    choices: [
-      { title: 'Global (recommended)', description: 'Available in all projects', value: 'global' },
-      { title: 'Project-local', description: 'Only this project', value: 'local' },
-      { title: 'Skip', value: 'skip' }
-    ],
-    initial: 0
-  });
+  const claudeWorkPending = needsClaude && !env.pluginInstalled;
+  const codexWorkPending = needsCodex && !env.codexPluginInstalled;
 
-  if (scope === 'skip' || !scope) {
-    console.log(chalk.yellow('  ○ Skipped plugin installation'));
-    return { success: false, scope: null };
+  // The scope prompt only affects the Claude install flow (`--local` vs global).
+  // Codex always writes a marketplace entry under ~/.agents/plugins/marketplace.json.
+  let scope = 'global';
+  if (claudeWorkPending) {
+    const promptMessage = codexWorkPending
+      ? 'Install pokayokay plugin (scope applies to Claude; Codex marketplace entry is global)?'
+      : 'Install pokayokay plugin for Claude?';
+    const response = await prompts({
+      type: 'select',
+      name: 'scope',
+      message: promptMessage,
+      choices: [
+        { title: 'Global (recommended)', description: 'Available in all projects', value: 'global' },
+        { title: 'Project-local', description: 'Only this project', value: 'local' },
+        { title: 'Skip', value: 'skip' }
+      ],
+      initial: 0
+    });
+    scope = response.scope;
+    if (scope === 'skip' || !scope) {
+      console.log(chalk.yellow('  ○ Skipped plugin installation'));
+      return { success: false, scope: null };
+    }
+  } else if (codexWorkPending) {
+    // Codex-only flow: confirm intent, no scope question.
+    const { proceed } = await prompts({
+      type: 'confirm',
+      name: 'proceed',
+      message: 'Write pokayokay marketplace entry for Codex (~/.agents/plugins/marketplace.json)?',
+      initial: true
+    });
+    if (!proceed) {
+      console.log(chalk.yellow('  ○ Skipped Codex marketplace entry'));
+      return { success: false, scope: null };
+    }
   }
 
   const installedScopes = [];
 
-  if (needsClaude && !env.pluginInstalled) {
+  if (claudeWorkPending) {
     // Add marketplace (ignore errors if already added)
     console.log('  Adding Claude marketplace...');
     const addResult = await execute('claude', ['plugin', 'marketplace', 'add', 'srstomp/pokayokay']);
@@ -117,16 +145,19 @@ export async function installPlugin(env) {
       return { success: false, scope: null };
     }
 
+    console.log(chalk.green(`  ✓ Claude plugin installed (${scope})`));
     installedScopes.push(`Claude ${scope}`);
   }
 
-  if (needsCodex && !env.codexPluginInstalled) {
+  if (codexWorkPending) {
     const marketplacePath = ensureCodexMarketplaceEntry();
+    // Be explicit: we only wrote a marketplace entry. Codex still needs to
+    // load/activate it (the user does this with `codex plugin install`).
     console.log(chalk.green(`  ✓ Codex marketplace entry written to ${marketplacePath}`));
-    installedScopes.push('Codex marketplace');
+    console.log(chalk.dim('    Run `codex plugin install pokayokay` to activate it in Codex.'));
+    installedScopes.push('Codex marketplace entry');
   }
 
   const resultScope = installedScopes.join(', ') || scope;
-  console.log(chalk.green(`  ✓ Plugin installed (${resultScope})`));
   return { success: true, scope: resultScope };
 }

--- a/cli/src/steps/plugin.js
+++ b/cli/src/steps/plugin.js
@@ -1,11 +1,50 @@
 import prompts from 'prompts';
 import chalk from 'chalk';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execute } from '../utils/execute.js';
 
+/**
+ * Find the on-disk pokayokay plugin source. The published CLI package ships
+ * only `bin/` and `src/`, so a relative path under `process.cwd()` only works
+ * when the user runs from a checkout of the pokayokay repo. Try the cwd
+ * first; fall back to a sibling of the CLI source (covers `npm link` and
+ * monorepo-style installs); return null if nothing is found so the caller
+ * can surface a clear error instead of writing a broken marketplace entry.
+ *
+ * @returns {string|null} Absolute path to the plugin directory, or null.
+ */
+function locatePluginSource() {
+  const cwdCandidate = resolve(process.cwd(), 'plugins', 'pokayokay');
+  if (existsSync(join(cwdCandidate, '.codex-plugin', 'plugin.json'))) {
+    return cwdCandidate;
+  }
+
+  // cli/src/steps/plugin.js → cli/src/steps → cli/src → cli → repo root → plugins/pokayokay
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const repoCandidate = resolve(moduleDir, '..', '..', '..', 'plugins', 'pokayokay');
+  if (existsSync(join(repoCandidate, '.codex-plugin', 'plugin.json'))) {
+    return repoCandidate;
+  }
+
+  return null;
+}
+
 function ensureCodexMarketplaceEntry() {
+  const pluginPath = locatePluginSource();
+  if (!pluginPath) {
+    const cwd = process.cwd();
+    throw new Error(
+      `Could not find the pokayokay plugin source. Looked in:\n` +
+      `  - ${join(cwd, 'plugins', 'pokayokay')} (cwd)\n` +
+      `  - sibling of the CLI install (npm package layout)\n` +
+      `Run setup from a checkout of the pokayokay repo, e.g.:\n` +
+      `  git clone https://github.com/srstomp/pokayokay && cd pokayokay && npx pokayokay`
+    );
+  }
+
   const agentsDir = join(homedir(), '.agents', 'plugins');
   const marketplacePath = join(agentsDir, 'marketplace.json');
   mkdirSync(agentsDir, { recursive: true });
@@ -24,14 +63,19 @@ function ensureCodexMarketplaceEntry() {
       marketplace.plugins = marketplace.plugins || [];
       marketplace.interface = marketplace.interface || { displayName: 'Local Plugins' };
     } catch {
-      // Replace invalid marketplace JSON with a valid local marketplace.
+      // The existing marketplace is invalid JSON. Preserve user-owned state
+      // by copying it to a timestamped backup before we overwrite it with a
+      // fresh default — a transient parse/write issue should never silently
+      // erase entries.
+      const backupPath = `${marketplacePath}.backup-${Date.now()}`;
+      try {
+        copyFileSync(marketplacePath, backupPath);
+        console.log(chalk.yellow(`  ⚠ Invalid marketplace JSON; backed up to ${backupPath}`));
+      } catch (backupErr) {
+        console.log(chalk.yellow(`  ⚠ Invalid marketplace JSON; backup failed (${backupErr.message})`));
+      }
     }
   }
-
-  // The marketplace file lives under the user home directory, so a relative
-  // plugin path would be ambiguous. Resolve to an absolute path against the
-  // current working directory (the project root the user ran setup from).
-  const pluginPath = resolve(process.cwd(), 'plugins', 'pokayokay');
 
   const entry = {
     name: 'pokayokay',
@@ -150,12 +194,21 @@ export async function installPlugin(env) {
   }
 
   if (codexWorkPending) {
-    const marketplacePath = ensureCodexMarketplaceEntry();
-    // Be explicit: we only wrote a marketplace entry. Codex still needs to
-    // load/activate it (the user does this with `codex plugin install`).
-    console.log(chalk.green(`  ✓ Codex marketplace entry written to ${marketplacePath}`));
-    console.log(chalk.dim('    Run `codex plugin install pokayokay` to activate it in Codex.'));
-    installedScopes.push('Codex marketplace entry');
+    try {
+      const marketplacePath = ensureCodexMarketplaceEntry();
+      // Be explicit: we only wrote a marketplace entry. Codex still needs to
+      // load/activate it (the user does this with `codex plugin install`).
+      console.log(chalk.green(`  ✓ Codex marketplace entry written to ${marketplacePath}`));
+      console.log(chalk.dim('    Run `codex plugin install pokayokay` to activate it in Codex.'));
+      installedScopes.push('Codex marketplace entry');
+    } catch (err) {
+      console.log(chalk.red(`  ✗ Failed to write Codex marketplace entry:\n    ${err.message.replace(/\n/g, '\n    ')}`));
+      // If Claude was already installed in this run, keep that progress; only
+      // fail the whole step when nothing else succeeded.
+      if (installedScopes.length === 0) {
+        return { success: false, scope: null };
+      }
+    }
   }
 
   const resultScope = installedScopes.join(', ') || scope;

--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -46,6 +46,164 @@ export function writeClaudeConfig(configPath, config) {
   return backupPath;
 }
 
+function backupExisting(configPath) {
+  let backupPath = null;
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  if (existsSync(configPath)) {
+    backupPath = `${configPath}.backup-${Date.now()}`;
+    copyFileSync(configPath, backupPath);
+  }
+
+  return backupPath;
+}
+
+function quoteTomlString(value) {
+  return JSON.stringify(String(value));
+}
+
+function formatTomlStringArray(values) {
+  return `[${values.map(quoteTomlString).join(', ')}]`;
+}
+
+function parseTomlArray(value) {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map((item) => item.trim().replace(/^"|"$/g, ''))
+      .filter(Boolean);
+  }
+}
+
+/**
+ * Read the subset of Codex config.toml needed by pokayokay.
+ * @param {string} configPath - Path to config.toml
+ * @returns {object} Parsed config with mcpServers
+ */
+export function readCodexConfig(configPath) {
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  const config = { mcpServers: {} };
+  let currentMcpServer = null;
+
+  for (const line of readFileSync(configPath, 'utf-8').split(/\r?\n/)) {
+    const section = line.match(/^\[mcp_servers\.([^\]]+)\]\s*$/);
+    if (section) {
+      currentMcpServer = section[1].replace(/^"|"$/g, '');
+      config.mcpServers[currentMcpServer] = config.mcpServers[currentMcpServer] || {};
+      continue;
+    }
+
+    if (line.startsWith('[')) {
+      currentMcpServer = null;
+      continue;
+    }
+
+    if (!currentMcpServer) {
+      continue;
+    }
+
+    const command = line.match(/^\s*command\s*=\s*"([^"]*)"\s*$/);
+    if (command) {
+      config.mcpServers[currentMcpServer].command = command[1];
+      continue;
+    }
+
+    const args = line.match(/^\s*args\s*=\s*(\[.*\])\s*$/);
+    if (args) {
+      config.mcpServers[currentMcpServer].args = parseTomlArray(args[1]);
+    }
+  }
+
+  return Object.keys(config.mcpServers).length ? config : {};
+}
+
+/**
+ * Add or replace one MCP server in a Codex config object.
+ * @param {object} config - Existing parsed config
+ * @param {string} serverName - MCP server name
+ * @param {object} serverConfig - MCP server config
+ * @returns {object} New config object
+ */
+export function upsertCodexMcpServer(config, serverName, serverConfig) {
+  return {
+    ...config,
+    mcpServers: {
+      ...(config.mcpServers || {}),
+      [serverName]: serverConfig,
+    },
+  };
+}
+
+function codexMcpSection(serverName, serverConfig) {
+  const lines = [
+    `[mcp_servers.${serverName}]`,
+    `command = ${quoteTomlString(serverConfig.command)}`,
+  ];
+
+  if (serverConfig.args) {
+    lines.push(`args = ${formatTomlStringArray(serverConfig.args)}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Write a minimal Codex config.toml from a parsed config object.
+ * @param {string} configPath - Path to config.toml
+ * @param {object} config - Config object
+ * @returns {string|null} Backup path if created, null otherwise
+ */
+export function writeCodexConfig(configPath, config) {
+  const backupPath = backupExisting(configPath);
+  const sections = Object.entries(config.mcpServers || {})
+    .map(([name, server]) => codexMcpSection(name, server));
+
+  writeFileSync(configPath, `${sections.join('\n')}`.trimEnd() + '\n');
+  return backupPath;
+}
+
+/**
+ * Upsert one MCP server section into an existing Codex config.toml while
+ * preserving unrelated config.
+ * @param {string} configPath - Path to config.toml
+ * @param {string} serverName - MCP server name
+ * @param {object} serverConfig - MCP server config
+ * @returns {string|null} Backup path if created, null otherwise
+ */
+export function writeCodexMcpServer(configPath, serverName, serverConfig) {
+  const backupPath = backupExisting(configPath);
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+  const section = codexMcpSection(serverName, serverConfig);
+  const header = `[mcp_servers.${serverName}]`;
+  const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const sectionPattern = new RegExp(`${escaped}\\n[\\s\\S]*?(?=\\n\\[[^\\]]+\\]|\\s*$)`);
+
+  let next;
+  if (sectionPattern.test(existing)) {
+    next = existing.replace(sectionPattern, section.trimEnd());
+  } else {
+    const separator = existing.trim().length ? '\n\n' : '';
+    next = `${existing.trimEnd()}${separator}${section.trimEnd()}`;
+  }
+
+  writeFileSync(configPath, `${next.trimEnd()}\n`);
+  return backupPath;
+}
+
 /**
  * Check if MCP server is configured
  * @param {object} config - Claude config object

--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -186,7 +186,12 @@ export function writeCodexConfig(configPath, config) {
  */
 export function writeCodexMcpServer(configPath, serverName, serverConfig) {
   const backupPath = backupExisting(configPath);
-  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+  const rawExisting = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+  // Normalize line endings to LF so Windows-edited config.toml files
+  // (CRLF) are still recognized by the section-replacement regex; without
+  // this, a pre-existing `[mcp_servers.<name>]` block on CRLF would not
+  // match and we'd append a duplicate section.
+  const existing = rawExisting.replace(/\r\n/g, '\n');
   const section = codexMcpSection(serverName, serverConfig);
   const header = `[mcp_servers.${serverName}]`;
   const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/cli/src/utils/execute.js
+++ b/cli/src/utils/execute.js
@@ -51,3 +51,16 @@ export async function getClaudeVersion() {
   }
   return null;
 }
+
+/**
+ * Get Codex version.
+ * @returns {Promise<string|null>} Version string or null if not installed
+ */
+export async function getCodexVersion() {
+  const result = await execute('codex', ['--version']);
+  if (result.success) {
+    const match = result.stdout.match(/v?(\d+\.\d+\.\d+)/);
+    return match ? match[1] : result.stdout.trim();
+  }
+  return null;
+}

--- a/cli/src/utils/platform.js
+++ b/cli/src/utils/platform.js
@@ -26,6 +26,22 @@ export function getClaudeConfigPath() {
 }
 
 /**
+ * Get Codex config directory path.
+ * @returns {string} Path to Codex config directory
+ */
+export function getCodexConfigDir() {
+  return join(homedir(), '.codex');
+}
+
+/**
+ * Get Codex config.toml path.
+ * @returns {string} Path to Codex config.toml
+ */
+export function getCodexConfigPath() {
+  return join(getCodexConfigDir(), 'config.toml');
+}
+
+/**
  * Get platform display name
  * @returns {string} Human-readable platform name
  */

--- a/docs/plans/2026-04-24-dual-runtime-codex-support.md
+++ b/docs/plans/2026-04-24-dual-runtime-codex-support.md
@@ -1,0 +1,75 @@
+# Dual Runtime Codex Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Codex plugin support beside existing Claude Code support without removing or weakening the Claude runtime path.
+
+**Architecture:** Keep Pokayokay's commands, skills, agents, and hook scripts shared. Add Codex-specific manifests/config files, make the CLI detect and configure both runtimes, and normalize hook payloads before routing them through the existing bridge logic.
+
+**Tech Stack:** Shell tests, Node.js ESM CLI modules, Python hook bridge, JSON/TOML-like config generation, existing Pokayokay plugin layout.
+
+---
+
+### Task 1: Red Tests for Dual Runtime Surface
+
+**Files:**
+- Create: `plugins/pokayokay/tests/codex-compatibility.test.sh`
+- Create: `plugins/pokayokay/tests/cli-dual-runtime.test.mjs`
+- Create: `plugins/pokayokay/tests/bridge-runtime-normalization.test.sh`
+
+**Step 1:** Write failing tests that assert `.codex-plugin/plugin.json`, plugin `.mcp.json`, and Codex hook config exist while `.claude-plugin/plugin.json` remains.
+
+**Step 2:** Write failing CLI tests for Codex config path helpers, MCP config writing, and runtime selection defaults.
+
+**Step 3:** Write failing bridge tests showing Claude-style and Codex-style payloads both route file changes to the same WIP update behavior.
+
+### Task 2: Codex Plugin Files
+
+**Files:**
+- Create: `plugins/pokayokay/.codex-plugin/plugin.json`
+- Create: `plugins/pokayokay/.mcp.json`
+- Create: `plugins/pokayokay/hooks.json`
+
+**Steps:**
+- Add Codex manifest metadata pointing at shared skills and MCP config.
+- Add ohno MCP config.
+- Add a conservative hook config that calls the existing bridge script.
+
+### Task 3: CLI Platform Layer
+
+**Files:**
+- Modify: `cli/src/utils/platform.js`
+- Modify: `cli/src/utils/config.js`
+- Modify: `cli/src/utils/execute.js`
+- Modify: `cli/src/detect.js`
+- Modify: `cli/src/steps/mcp.js`
+- Modify: `cli/src/steps/plugin.js`
+- Modify: `cli/src/index.js`
+
+**Steps:**
+- Add Codex config path helpers and read/write support for `~/.codex/config.toml`.
+- Detect `codex` alongside `claude`.
+- Let the setup wizard target Claude, Codex, or both.
+- Preserve all existing Claude config behavior.
+
+### Task 4: Runtime-Neutral Bridge
+
+**Files:**
+- Modify: `plugins/pokayokay/hooks/actions/bridge.py`
+
+**Steps:**
+- Add a small normalization layer that accepts existing Claude payloads unchanged.
+- Add support for Codex-style aliases such as lowercase tool names and `event`/`hook_event` fields.
+- Use `YOKAY_PROJECT_DIR` and `CODEX_WORKSPACE_DIR` before falling back to `CLAUDE_PROJECT_DIR`/cwd.
+
+### Task 5: Docs and Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `cli/README.md`
+- Modify: selected command docs with Claude-only continuation language.
+
+**Steps:**
+- Present Pokayokay as Claude Code plus Codex compatible.
+- Keep Claude install docs intact while adding Codex notes.
+- Run focused new tests, then the relevant existing hook tests.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "AI-powered development workflows with task tracking, skill-based routing, and guaranteed execution hooks",
   "keywords": [
     "claude-code",
+    "codex",
     "plugin",
     "skills",
     "ai",

--- a/plugins/pokayokay/.codex-plugin/plugin.json
+++ b/plugins/pokayokay/.codex-plugin/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "pokayokay",
+  "version": "0.22.0",
+  "description": "AI-assisted development orchestration with task tracking, skills, hooks, and ohno integration.",
+  "author": {
+    "name": "Steve Stomp",
+    "url": "https://github.com/srstomp"
+  },
+  "homepage": "https://github.com/srstomp/pokayokay",
+  "repository": "https://github.com/srstomp/pokayokay",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "claude-code",
+    "development-workflows",
+    "task-management",
+    "skills",
+    "orchestration",
+    "ohno",
+    "hooks",
+    "audit"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Pokayokay",
+    "shortDescription": "Structured AI development workflows for Codex and Claude Code",
+    "longDescription": "Pokayokay orchestrates AI-assisted development sessions with task tracking, skills, hooks, worktree guidance, audits, and ohno integration. Codex support is additive and keeps Claude Code support intact.",
+    "developerName": "Steve Stomp",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/srstomp/pokayokay",
+    "privacyPolicyURL": "https://github.com/srstomp/pokayokay",
+    "termsOfServiceURL": "https://github.com/srstomp/pokayokay",
+    "defaultPrompt": [
+      "Plan this PRD with Pokayokay",
+      "Start a supervised work session",
+      "Audit this feature for gaps"
+    ],
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/plugins/pokayokay/.mcp.json
+++ b/plugins/pokayokay/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "ohno": {
+      "command": "npx",
+      "args": [
+        "@stevestomp/ohno-mcp"
+      ]
+    }
+  }
+}

--- a/plugins/pokayokay/commands/work.md
+++ b/plugins/pokayokay/commands/work.md
@@ -30,7 +30,7 @@ Example arguments:
 - `--continue` → resume from WIP, inherit previous scope
 - `--all` → work on all available tasks (no scope filter)
 
-Note: `-p` is reserved for the claude CLI `--prompt` flag. Use `-n` for parallel count.
+Note: `-p` is commonly reserved by AI runtime CLIs for prompt input. Use `-n` for parallel count.
 
 ## Worktree Argument Parsing
 
@@ -49,7 +49,7 @@ Headless mode enables automatic session chaining when context fills up.
 
 ### Configuration
 
-Read headless config from `.claude/pokayokay.json` (create if missing):
+Read headless config from `.pokayokay/config.json` when present, falling back to `.claude/pokayokay.json` for existing Claude Code projects:
 
 ```json
 {
@@ -117,9 +117,13 @@ When a session reaches context limits:
      "tasks_remaining": 8
    }
    ```
-4. SessionEnd hook spawns next session:
+4. SessionEnd hook spawns or prepares the next session using the active runtime:
    ```bash
+   # Claude Code
    claude --headless --prompt="/work --continue --epic epic-abc123"
+
+   # Codex
+   codex --prompt="/work --continue --epic epic-abc123"
    ```
 
 ### Chain Reporting
@@ -205,7 +209,7 @@ degrades from repeated compaction.
 ### Detection
 
 Context pressure is detected when **any** of these occur:
-1. Claude Code compacts the conversation (you'll see "Compacting conversation..." in output)
+1. The active runtime compacts the conversation (for example, Claude Code shows "Compacting conversation..." in output)
 2. A system reminder mentions context limits
 3. You notice repeated information loss from prior context
 
@@ -222,7 +226,7 @@ When context pressure is detected during a chained session:
    ```
 4. **Save coordinator state** to chain state file:
    ```
-   Read existing .claude/pokayokay-chain-state.json
+   Read existing .pokayokay/pokayokay-chain-state.json, falling back to .claude/pokayokay-chain-state.json
    Update with:
      adaptive_n: current parallel count
      batches_completed: count
@@ -230,14 +234,14 @@ When context pressure is detected during a chained session:
      failed_tasks: [task IDs that failed/blocked]
      conflict_tasks: [task IDs with git conflicts]
      last_session_summary: "Completed X tasks, Y failed, Z conflicts"
-   Write back to .claude/pokayokay-chain-state.json
+   Write back to .pokayokay/pokayokay-chain-state.json
    ```
 5. **Log session summary**:
    ```
    add_task_activity(task_id, "note", "Session ending: context pressure detected, chaining to next session")
    ```
 6. **End the session** — output a brief summary and stop. This triggers:
-   - SessionEnd hook → bridge.py reads chain state → session-chain.sh spawns next session
+   - SessionEnd hook → bridge.py reads chain state → session-chain.sh spawns/prepares the next runtime session
 
 ### Why Proactive?
 
@@ -254,13 +258,13 @@ With proactive shutdown:
 ### Non-Chained Sessions
 
 In supervised or semi-auto sessions (no chain state file), compaction is handled
-normally by Claude Code. The coordinator does NOT need to proactively end — the user
+normally by the active runtime. The coordinator does NOT need to proactively end — the user
 is present and can decide.
 
 ## Session Start
 
 ### 0. Load Configuration
-Read `.claude/pokayokay.json` for headless and work settings.
+Read `.pokayokay/config.json` for headless and work settings. If it does not exist, fall back to `.claude/pokayokay.json` so existing Claude Code projects keep working.
 
 ### 0.5 Load Project Learnings
 MEMORY.md is already in your system prompt. Additionally check topic files when relevant:
@@ -281,7 +285,7 @@ When starting a NEW auto or unattended session with scope (not `--continue`), wr
 so that SessionEnd hooks can spawn continuation sessions:
 
 ```
-Write .claude/pokayokay-chain-state.json:
+Write .pokayokay/pokayokay-chain-state.json:
 {
   "chain_id": "chain-<current-unix-timestamp>",
   "chain_index": 0,
@@ -314,7 +318,7 @@ Use ohno MCP `get_session_context` to understand:
 
 When `--continue` flag is set, resume from previous WIP instead of starting fresh:
 
-1. **Restore coordinator state**: Read `.claude/pokayokay-chain-state.json`. If it contains extended fields (`adaptive_n`, `failed_tasks`, etc.), restore them:
+1. **Restore coordinator state**: Read `.pokayokay/pokayokay-chain-state.json`, falling back to `.claude/pokayokay-chain-state.json`. If it contains extended fields (`adaptive_n`, `failed_tasks`, etc.), restore them:
    - `adaptive_state.current_n = chain_state.adaptive_n` (instead of reset to 2)
    - `adaptive_state.batches_completed = chain_state.batches_completed`
    - `adaptive_state.batches_failed = chain_state.batches_failed`
@@ -1835,7 +1839,7 @@ When session ends with remaining work in scope:
 1. SessionEnd hook calls `session-chain.sh`
 2. Script checks remaining ready tasks via ohno
 3. If tasks remain and chain limit not reached:
-   - Spawns: `claude --headless --prompt="/work --continue <scope-flag>"`
+   - Spawns/prepares the next session using the active runtime, for example `claude --headless --prompt="/work --continue <scope-flag>"` or `codex --prompt="/work --continue <scope-flag>"`
 4. If chain complete or limit reached:
    - Generates report to `.ohno/reports/chain-{id}-report.md`
    - Notifies via configured method
@@ -1843,7 +1847,7 @@ When session ends with remaining work in scope:
 
 #### Chain State File
 
-Chain state is communicated between the coordinator and hooks via `.claude/pokayokay-chain-state.json`.
+Chain state is communicated between the coordinator and hooks via `.pokayokay/pokayokay-chain-state.json`, with `.claude/pokayokay-chain-state.json` retained as a legacy fallback.
 
 **The coordinator MUST write this file at session start** when running auto mode with scope.
 Use the Write tool to create it:
@@ -2016,7 +2020,9 @@ If you discover a bug while working on a feature:
 /work semi-auto --epic epic-4fcd1e3c
 
 # Overnight unattended run (NEVER pauses, for headless CLI use)
-# Run with: claude --headless --dangerously-skip-permissions --prompt="..."
+# Run with your active runtime's non-interactive mode, for example:
+# claude --headless --dangerously-skip-permissions --prompt="..."
+# codex --prompt="..."
 /work unattended -n auto --all
 ```
 

--- a/plugins/pokayokay/hooks.json
+++ b/plugins/pokayokay/hooks.json
@@ -1,0 +1,46 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/actions/bridge.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/actions/bridge.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|bash|exec_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/actions/bridge.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/actions/bridge.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/pokayokay/hooks/actions/bridge.py
+++ b/plugins/pokayokay/hooks/actions/bridge.py
@@ -332,11 +332,47 @@ def handle_session_start(input_data: dict) -> dict:
     }
 
 
-def load_pokayokay_config() -> dict:
-    """Load pokayokay configuration from .claude/pokayokay.json."""
-    project_dir = get_project_dir()
-    config_path = Path(project_dir) / ".claude" / "pokayokay.json"
+# ==========================================================================
+# Runtime-agnostic state directory resolution
+# ==========================================================================
+#
+# Reads prefer ``.pokayokay/`` and fall back to ``.claude/`` so existing
+# Claude Code projects keep working. Writes go to whichever directory holds
+# the file already (preserves user choice); when neither exists, writes go
+# to ``.pokayokay/`` because it is runtime-agnostic.
 
+PRIMARY_STATE_DIR = ".pokayokay"
+LEGACY_STATE_DIR = ".claude"
+
+
+def _resolve_state_path(filename: str) -> Path:
+    """Return the path that should be read/written for a state file.
+
+    Prefers an existing file in ``.pokayokay/``, then ``.claude/``. When
+    neither file exists, returns the runtime-agnostic ``.pokayokay/`` path.
+    """
+    project_dir = Path(get_project_dir())
+    primary = project_dir / PRIMARY_STATE_DIR / filename
+    legacy = project_dir / LEGACY_STATE_DIR / filename
+
+    if primary.exists():
+        return primary
+    if legacy.exists():
+        return legacy
+    return primary
+
+
+def load_pokayokay_config() -> dict:
+    """Load pokayokay configuration.
+
+    Reads ``.pokayokay/config.json`` when present, falling back to
+    ``.claude/pokayokay.json`` for legacy Claude Code projects.
+    """
+    project_dir = Path(get_project_dir())
+    primary = project_dir / PRIMARY_STATE_DIR / "config.json"
+    legacy = project_dir / LEGACY_STATE_DIR / "pokayokay.json"
+
+    config_path = primary if primary.exists() else legacy
     if not config_path.exists():
         return {}
 
@@ -355,13 +391,12 @@ CHAIN_STATE_FILENAME = "pokayokay-chain-state.json"
 
 
 def _chain_state_path() -> Path:
-    """Get path to the chain state file."""
-    project_dir = get_project_dir()
-    return Path(project_dir) / ".claude" / CHAIN_STATE_FILENAME
+    """Get path to the chain state file (prefers .pokayokay/, falls back to .claude/)."""
+    return _resolve_state_path(CHAIN_STATE_FILENAME)
 
 
 def load_chain_state() -> dict:
-    """Load chain state from .claude/pokayokay-chain-state.json.
+    """Load chain state from .pokayokay/ or .claude/ (legacy fallback).
 
     Returns:
         Chain state dict with keys: chain_id, chain_index, scope_type,
@@ -379,7 +414,10 @@ def load_chain_state() -> dict:
 
 
 def save_chain_state(state: dict) -> None:
-    """Save chain state to .claude/pokayokay-chain-state.json.
+    """Save chain state to the active state directory.
+
+    Writes to whichever directory already holds the file; otherwise writes
+    to the runtime-agnostic ``.pokayokay/`` location.
 
     Uses atomic write (temp file + rename) to prevent corruption.
     """
@@ -399,13 +437,17 @@ def save_chain_state(state: dict) -> None:
 
 
 def delete_chain_state() -> None:
-    """Remove the chain state file (chain is done)."""
-    state_path = _chain_state_path()
-    try:
-        if state_path.exists():
-            state_path.unlink()
-    except OSError:
-        pass  # Best-effort cleanup
+    """Remove the chain state file from both possible locations."""
+    project_dir = Path(get_project_dir())
+    for candidate in (
+        project_dir / PRIMARY_STATE_DIR / CHAIN_STATE_FILENAME,
+        project_dir / LEGACY_STATE_DIR / CHAIN_STATE_FILENAME,
+    ):
+        try:
+            if candidate.exists():
+                candidate.unlink()
+        except OSError:
+            pass  # Best-effort cleanup
 
 
 # ==========================================================================
@@ -416,9 +458,8 @@ TOKEN_USAGE_FILENAME = "pokayokay-token-usage.json"
 
 
 def _token_usage_path() -> Path:
-    """Get path to the token usage file."""
-    project_dir = get_project_dir()
-    return Path(project_dir) / ".claude" / TOKEN_USAGE_FILENAME
+    """Get path to the token usage file (prefers .pokayokay/, falls back to .claude/)."""
+    return _resolve_state_path(TOKEN_USAGE_FILENAME)
 
 
 def load_token_usage() -> dict:
@@ -967,9 +1008,8 @@ CATEGORY_PATH_SCOPES: Dict[str, str] = {
 
 
 def _failure_tracking_path() -> Path:
-    """Get path to the review failure tracking file."""
-    project_dir = get_project_dir()
-    return Path(project_dir) / ".claude" / FAILURE_TRACKING_FILENAME
+    """Get path to the review failure tracking file (prefers .pokayokay/, falls back to .claude/)."""
+    return _resolve_state_path(FAILURE_TRACKING_FILENAME)
 
 
 def load_failure_tracking() -> dict:

--- a/plugins/pokayokay/hooks/actions/bridge.py
+++ b/plugins/pokayokay/hooks/actions/bridge.py
@@ -111,6 +111,77 @@ def get_script_dir() -> Path:
     return Path(__file__).parent
 
 
+def get_project_dir() -> str:
+    """Get the active project directory across supported runtimes."""
+    return (
+        os.environ.get("YOKAY_PROJECT_DIR")
+        or os.environ.get("CODEX_WORKSPACE_DIR")
+        or os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.getcwd()
+    )
+
+
+def normalize_tool_name(tool_name: str) -> str:
+    """Normalize runtime-specific tool aliases to the bridge's canonical names."""
+    aliases = {
+        "bash": "Bash",
+        "shell": "Bash",
+        "exec": "Bash",
+        "exec_command": "Bash",
+        "edit": "Edit",
+        "apply_patch": "Edit",
+        "write": "Write",
+        "skill": "Skill",
+        "task": "Task",
+        "agent": "Task",
+        "spawn_agent": "Task",
+        "mcp__ohno__update_task_status": "mcp__ohno__update_task_status",
+        "ohno.update_task_status": "mcp__ohno__update_task_status",
+        "update_task_status": "mcp__ohno__update_task_status",
+        "mcp__ohno__set_blocker": "mcp__ohno__set_blocker",
+        "ohno.set_blocker": "mcp__ohno__set_blocker",
+        "set_blocker": "mcp__ohno__set_blocker",
+    }
+
+    if tool_name in ("Bash", "Edit", "Write", "Skill", "Task"):
+        return tool_name
+
+    return aliases.get(str(tool_name).strip().lower(), tool_name)
+
+
+def normalize_hook_input(input_data: dict) -> dict:
+    """Normalize Claude/Codex hook payload aliases to one internal shape."""
+    normalized = dict(input_data)
+    raw_tool = (
+        input_data.get("tool_name")
+        or input_data.get("tool")
+        or input_data.get("toolName")
+        or ""
+    )
+    normalized["tool_name"] = normalize_tool_name(raw_tool)
+    normalized["tool_input"] = (
+        input_data.get("tool_input")
+        or input_data.get("input")
+        or input_data.get("arguments")
+        or {}
+    )
+    normalized["tool_response"] = (
+        input_data.get("tool_response")
+        or input_data.get("response")
+        or input_data.get("result")
+        or {}
+    )
+    normalized["hook_event_name"] = (
+        input_data.get("hook_event_name")
+        or input_data.get("hook_event")
+        or input_data.get("event")
+        or input_data.get("eventName")
+        or ""
+    )
+    normalized["runtime"] = input_data.get("runtime") or input_data.get("source") or "claude"
+    return normalized
+
+
 def check_rate_limit(hook_name: str) -> Optional[str]:
     """
     Check if a hook has exceeded its rate limit.
@@ -174,7 +245,7 @@ def run_action(name: str, args: Optional[List[str]] = None, env: Optional[Dict[s
             text=True,
             timeout=timeout,
             env=run_env,
-            cwd=os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+            cwd=get_project_dir()
         )
 
         return {
@@ -263,7 +334,7 @@ def handle_session_start(input_data: dict) -> dict:
 
 def load_pokayokay_config() -> dict:
     """Load pokayokay configuration from .claude/pokayokay.json."""
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     config_path = Path(project_dir) / ".claude" / "pokayokay.json"
 
     if not config_path.exists():
@@ -285,7 +356,7 @@ CHAIN_STATE_FILENAME = "pokayokay-chain-state.json"
 
 def _chain_state_path() -> Path:
     """Get path to the chain state file."""
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     return Path(project_dir) / ".claude" / CHAIN_STATE_FILENAME
 
 
@@ -346,7 +417,7 @@ TOKEN_USAGE_FILENAME = "pokayokay-token-usage.json"
 
 def _token_usage_path() -> Path:
     """Get path to the token usage file."""
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     return Path(project_dir) / ".claude" / TOKEN_USAGE_FILENAME
 
 
@@ -426,7 +497,7 @@ def _get_memory_dir() -> Optional[Path]:
     Checks Claude's project memory directory first, falls back to project-local.
     Returns None if neither can be determined.
     """
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     project_key = project_dir.replace("/", "-").lstrip("-")
     claude_memory = Path.home() / ".claude" / "projects" / project_key / "memory"
     if claude_memory.exists():
@@ -441,7 +512,7 @@ def _write_chain_learnings(chain_state: dict, tasks_completed_count: int) -> Non
     """Write chain progress to memory at session end."""
     target_dir = _get_memory_dir()
     if target_dir is None:
-        target_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())) / "memory"
+        target_dir = Path(get_project_dir()) / "memory"
     target_dir.mkdir(parents=True, exist_ok=True)
 
     learnings_file = target_dir / "chain-learnings.md"
@@ -495,7 +566,7 @@ def _write_spike_result(task_id: str, task_title: str, task_notes: str) -> None:
     """Write spike GO/NO-GO result to memory."""
     target_dir = _get_memory_dir()
     if target_dir is None:
-        target_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())) / "memory"
+        target_dir = Path(get_project_dir()) / "memory"
     target_dir.mkdir(parents=True, exist_ok=True)
 
     spike_file = target_dir / "spike-results.md"
@@ -897,7 +968,7 @@ CATEGORY_PATH_SCOPES: Dict[str, str] = {
 
 def _failure_tracking_path() -> Path:
     """Get path to the review failure tracking file."""
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     return Path(project_dir) / ".claude" / FAILURE_TRACKING_FILENAME
 
 
@@ -942,7 +1013,7 @@ def write_recurring_failure_to_memory(category: str, count: int, recent_context:
     """Write a recurring failure pattern to memory/recurring-failures.md."""
     target_dir = _get_memory_dir()
     if target_dir is None:
-        target_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())) / "memory"
+        target_dir = Path(get_project_dir()) / "memory"
     target_dir.mkdir(parents=True, exist_ok=True)
 
     failures_file = target_dir / "recurring-failures.md"
@@ -1099,7 +1170,7 @@ def handle_review_complete(tool_input: dict, tool_response: dict) -> dict:
 
     # Call post-review-fail hook (located in project root hooks/ directory)
     # This hook integrates with kaizen if installed, otherwise logs gracefully
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     hook_path = Path(project_dir) / "hooks" / "post-review-fail.sh"
 
     if not hook_path.exists():
@@ -1174,7 +1245,7 @@ def run_action_at_path(script_path: Path, env: Optional[Dict[str, str]] = None) 
             text=True,
             timeout=timeout,
             env=run_env,
-            cwd=os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+            cwd=get_project_dir()
         )
 
         return {
@@ -1375,6 +1446,7 @@ def main():
         print(json.dumps({"error": f"Invalid JSON input: {e}"}))
         sys.exit(2)
 
+    input_data = normalize_hook_input(input_data)
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
     tool_response = input_data.get("tool_response", {})

--- a/plugins/pokayokay/hooks/actions/bridge.py
+++ b/plugins/pokayokay/hooks/actions/bridge.py
@@ -179,6 +179,19 @@ def normalize_hook_input(input_data: dict) -> dict:
         or ""
     )
     normalized["runtime"] = input_data.get("runtime") or input_data.get("source") or "claude"
+
+    # Codex passes shell commands as ``tool_input.cmd``; the rest of the
+    # bridge (handle_pre_commit, handle_bash_execution, parse_error) expects
+    # ``tool_input.command``. Mirror inner field aliases so Codex shell calls
+    # exercise the same code paths as Claude Code Bash calls.
+    tool_input = normalized.get("tool_input")
+    if isinstance(tool_input, dict) and normalized["tool_name"] == "Bash":
+        if "command" not in tool_input:
+            for alias in ("cmd", "shell_command", "command_line"):
+                if alias in tool_input:
+                    tool_input["command"] = tool_input[alias]
+                    break
+
     return normalized
 
 
@@ -1317,17 +1330,20 @@ def should_update_wip(force: bool = False) -> bool:
 
 
 def extract_output_text(tool_response) -> str:
-    """Extract text output from tool response (handles various formats)."""
+    """Extract text output from tool response (handles Claude and Codex formats)."""
     if isinstance(tool_response, str):
         return tool_response
     if isinstance(tool_response, dict):
-        content = tool_response.get("content", [])
-        if isinstance(content, list):
-            return "\n".join(c.get("text", "") for c in content if isinstance(c, dict))
-        if isinstance(content, str):
+        # Claude Code shape: {"content": [{"text": "..."}]} or {"content": "..."}
+        content = tool_response.get("content")
+        if isinstance(content, list) and content:
+            joined = "\n".join(c.get("text", "") for c in content if isinstance(c, dict))
+            if joined:
+                return joined
+        if isinstance(content, str) and content:
             return content
-        # Try direct text field
-        return tool_response.get("text", tool_response.get("output", ""))
+        # Codex / fallback shape: {"output": "..."} or {"text": "..."}
+        return tool_response.get("output") or tool_response.get("text") or ""
     return ""
 
 

--- a/plugins/pokayokay/hooks/actions/pre-flight.sh
+++ b/plugins/pokayokay/hooks/actions/pre-flight.sh
@@ -85,8 +85,17 @@ else
 fi
 
 # 6. Chain state file valid (if --continue)
-CHAIN_STATE="${PROJECT_DIR}/.claude/pokayokay-chain-state.json"
-if [ -f "$CHAIN_STATE" ]; then
+# Prefer .pokayokay/, fall back to .claude/ for legacy projects.
+CHAIN_STATE_PRIMARY="${PROJECT_DIR}/.pokayokay/pokayokay-chain-state.json"
+CHAIN_STATE_LEGACY="${PROJECT_DIR}/.claude/pokayokay-chain-state.json"
+if [ -f "$CHAIN_STATE_PRIMARY" ]; then
+    CHAIN_STATE="$CHAIN_STATE_PRIMARY"
+elif [ -f "$CHAIN_STATE_LEGACY" ]; then
+    CHAIN_STATE="$CHAIN_STATE_LEGACY"
+else
+    CHAIN_STATE=""
+fi
+if [ -n "$CHAIN_STATE" ]; then
     if python3 -c "import json; json.load(open('$CHAIN_STATE'))" 2>/dev/null; then
         echo "CHECK=chain_state OK"
     else

--- a/plugins/pokayokay/hooks/actions/session-summary.sh
+++ b/plugins/pokayokay/hooks/actions/session-summary.sh
@@ -15,8 +15,13 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   UNCOMMITTED=$(git status --short 2>/dev/null)
 fi
 
-# Read token usage from bridge-managed state file
-TOKEN_FILE=".claude/pokayokay-token-usage.json"
+# Read token usage from bridge-managed state file.
+# Prefer .pokayokay/, fall back to .claude/ for legacy projects.
+if [ -f ".pokayokay/pokayokay-token-usage.json" ]; then
+  TOKEN_FILE=".pokayokay/pokayokay-token-usage.json"
+else
+  TOKEN_FILE=".claude/pokayokay-token-usage.json"
+fi
 AGENT_COUNT=0
 TOTAL_TOKENS=0
 TOKEN_DETAILS=""

--- a/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
+++ b/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+trap 'rm -rf -- "$TEST_DIR"' EXIT
 
 BRIDGE="$(cd "$(dirname "$0")/.." && pwd)/hooks/actions/bridge.py"
 

--- a/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
+++ b/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
@@ -46,6 +46,22 @@ assert_last_file() {
   fi
 }
 
+assert_last_commit_hash() {
+  local expected="$1"
+  if [[ ! -f "$TEST_DIR/wip_calls/last_call.json" ]]; then
+    echo "  FAIL: no WIP update captured"
+    exit 1
+  fi
+  local hash
+  hash=$(jq -r '.last_commit // empty' "$TEST_DIR/wip_calls/last_call.json" 2>/dev/null || echo "")
+  if [[ "$hash" == "$expected" ]]; then
+    echo "  PASS: captured commit $expected"
+  else
+    echo "  FAIL: expected commit $expected, got '$hash'"
+    exit 1
+  fi
+}
+
 echo "Test 1: Existing Claude-style payload still works"
 echo '{"tool_name":"Edit","tool_input":{"file_path":"src/claude.ts"},"tool_response":{},"hook_event_name":"PostToolUse"}' |
   python3 "$BRIDGE" > /dev/null
@@ -63,6 +79,21 @@ export CODEX_WORKSPACE_DIR="$TEST_DIR"
 echo '{"runtime":"codex","tool_name":"write","tool_input":{"file_path":"src/workspace.ts"},"tool_response":{},"hook_event":"PostToolUse"}' |
   python3 "$BRIDGE" > /dev/null
 assert_last_file "src/workspace.ts"
+
+echo "Test 4: Codex Bash payload (cmd field) produces a real commit-hash WIP update"
+# Codex passes shell commands as tool_input.cmd; the bridge must remap to
+# tool_input.command so handle_bash_execution / extract_commit_hash actually
+# parse the git output. Without the alias the WIP update would skip silently.
+rm -f "$TEST_DIR/wip_calls/last_call.json"
+echo '{"runtime":"codex","tool":"exec_command","input":{"cmd":"git commit -m test"},"response":{"output":"[main abc1234] commit message"},"event":"PostToolUse"}' |
+  python3 "$BRIDGE" > /dev/null
+assert_last_commit_hash "abc1234"
+
+echo "Test 5: Codex Bash payload still routes when tool_name is the canonical Bash"
+rm -f "$TEST_DIR/wip_calls/last_call.json"
+echo '{"runtime":"codex","tool_name":"Bash","tool_input":{"cmd":"git commit -m hello"},"tool_response":{"output":"[feat def5678] another"},"hook_event_name":"PostToolUse"}' |
+  python3 "$BRIDGE" > /dev/null
+assert_last_commit_hash "def5678"
 
 echo ""
 echo "All bridge runtime normalization tests passed!"

--- a/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
+++ b/plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Validate bridge.py accepts Claude-style and Codex-style hook payload aliases.
+
+set -euo pipefail
+
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+BRIDGE="$(cd "$(dirname "$0")/.." && pwd)/hooks/actions/bridge.py"
+
+echo "Testing bridge runtime normalization..."
+
+cd "$TEST_DIR"
+
+MOCK_BIN="$TEST_DIR/bin"
+mkdir -p "$MOCK_BIN" "$TEST_DIR/wip_calls"
+
+cat > "$MOCK_BIN/npx" << EOF
+#!/usr/bin/env bash
+if [ "\$2" = "update-wip" ]; then
+  echo "\$4" > "$TEST_DIR/wip_calls/last_call.json"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_BIN/npx"
+
+export PATH="$MOCK_BIN:$PATH"
+export CURRENT_OHNO_TASK_ID="task-runtime"
+
+assert_last_file() {
+  local expected="$1"
+  if [[ ! -f "$TEST_DIR/wip_calls/last_call.json" ]]; then
+    echo "  FAIL: no WIP update captured"
+    exit 1
+  fi
+
+  local files
+  files=$(cat "$TEST_DIR/wip_calls/last_call.json" | jq -r '.files_modified[]' 2>/dev/null || echo "")
+  if [[ "$files" == *"$expected"* ]]; then
+    echo "  PASS: captured $expected"
+  else
+    echo "  FAIL: expected $expected in WIP update"
+    echo "  Files: $files"
+    exit 1
+  fi
+}
+
+echo "Test 1: Existing Claude-style payload still works"
+echo '{"tool_name":"Edit","tool_input":{"file_path":"src/claude.ts"},"tool_response":{},"hook_event_name":"PostToolUse"}' |
+  python3 "$BRIDGE" > /dev/null
+assert_last_file "src/claude.ts"
+
+echo "Test 2: Codex-style aliases route to the same handler"
+rm -f "$TEST_DIR/wip_calls/last_call.json"
+echo '{"runtime":"codex","tool":"edit","input":{"file_path":"src/codex.ts"},"response":{},"event":"PostToolUse"}' |
+  python3 "$BRIDGE" > /dev/null
+assert_last_file "src/codex.ts"
+
+echo "Test 3: CODEX_WORKSPACE_DIR is accepted as project dir"
+rm -f "$TEST_DIR/wip_calls/last_call.json"
+export CODEX_WORKSPACE_DIR="$TEST_DIR"
+echo '{"runtime":"codex","tool_name":"write","tool_input":{"file_path":"src/workspace.ts"},"tool_response":{},"hook_event":"PostToolUse"}' |
+  python3 "$BRIDGE" > /dev/null
+assert_last_file "src/workspace.ts"
+
+echo ""
+echo "All bridge runtime normalization tests passed!"

--- a/plugins/pokayokay/tests/cli-dual-runtime.test.mjs
+++ b/plugins/pokayokay/tests/cli-dual-runtime.test.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getCodexConfigDir,
+  getCodexConfigPath,
+  getClaudeConfigPath,
+} from '../../../cli/src/utils/platform.js';
+import {
+  isMcpConfigured,
+  readCodexConfig,
+  writeCodexConfig,
+  upsertCodexMcpServer,
+} from '../../../cli/src/utils/config.js';
+import { selectDefaultInstallTargets } from '../../../cli/src/detect.js';
+
+console.log('Testing CLI dual-runtime helpers...');
+
+console.log('Test 1: Codex config helpers are separate from Claude');
+assert.ok(getCodexConfigDir().endsWith('.codex'));
+assert.ok(getCodexConfigPath().endsWith(join('.codex', 'config.toml')));
+assert.notEqual(getCodexConfigPath(), getClaudeConfigPath());
+console.log('  PASS: config paths are runtime-specific');
+
+console.log('Test 2: Codex MCP config can be written and read');
+const tempDir = mkdtempSync(join(tmpdir(), 'pokayokay-codex-config-'));
+try {
+  const configPath = join(tempDir, 'config.toml');
+  const backupPath = writeCodexConfig(configPath, {
+    mcpServers: {
+      ohno: {
+        command: 'npx',
+        args: ['@stevestomp/ohno-mcp'],
+      },
+    },
+  });
+  assert.equal(backupPath, null);
+  const content = readFileSync(configPath, 'utf8');
+  assert.match(content, /\[mcp_servers\.ohno\]/);
+  assert.match(content, /command = "npx"/);
+  assert.match(content, /args = \["@stevestomp\/ohno-mcp"\]/);
+
+  const parsed = readCodexConfig(configPath);
+  assert.equal(parsed.mcpServers.ohno.command, 'npx');
+  assert.deepEqual(parsed.mcpServers.ohno.args, ['@stevestomp/ohno-mcp']);
+  assert.equal(isMcpConfigured(parsed, 'ohno'), true);
+  console.log('  PASS: Codex config round-trips ohno MCP');
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+console.log('Test 3: Codex MCP upsert preserves existing servers');
+const updated = upsertCodexMcpServer(
+  {
+    mcpServers: {
+      github: {
+        command: 'npx',
+        args: ['github-mcp'],
+      },
+    },
+  },
+  'ohno',
+  { command: 'npx', args: ['@stevestomp/ohno-mcp'] }
+);
+assert.equal(updated.mcpServers.github.command, 'npx');
+assert.equal(updated.mcpServers.ohno.command, 'npx');
+console.log('  PASS: upsert preserves other MCP servers');
+
+console.log('Test 4: default install target includes all detected runtimes');
+assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: true, codexInstalled: true }), ['claude', 'codex']);
+assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: true, codexInstalled: false }), ['claude']);
+assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: false, codexInstalled: true }), ['codex']);
+console.log('  PASS: runtime target defaults are dual-runtime aware');
+
+console.log('');
+console.log('All CLI dual-runtime tests passed!');

--- a/plugins/pokayokay/tests/cli-dual-runtime.test.mjs
+++ b/plugins/pokayokay/tests/cli-dual-runtime.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -13,6 +13,7 @@ import {
   isMcpConfigured,
   readCodexConfig,
   writeCodexConfig,
+  writeCodexMcpServer,
   upsertCodexMcpServer,
 } from '../../../cli/src/utils/config.js';
 import { selectDefaultInstallTargets } from '../../../cli/src/detect.js';
@@ -74,6 +75,33 @@ assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: true, codexInsta
 assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: true, codexInstalled: false }), ['claude']);
 assert.deepEqual(selectDefaultInstallTargets({ claudeInstalled: false, codexInstalled: true }), ['codex']);
 console.log('  PASS: runtime target defaults are dual-runtime aware');
+
+console.log('Test 5: writeCodexMcpServer is idempotent on CRLF-encoded configs');
+// On Windows, ~/.codex/config.toml may use CRLF line endings. Without the
+// CRLF normalization in config.js, the section-replacement regex would
+// miss the existing block and append a duplicate `[mcp_servers.<name>]`
+// section. This test pins down that idempotence.
+{
+  const crlfDir = mkdtempSync(join(tmpdir(), 'pokayokay-codex-crlf-'));
+  try {
+    const configPath = join(crlfDir, 'config.toml');
+    const initial = '[mcp_servers.ohno]\ncommand = "npx"\nargs = ["old"]\n';
+    writeFileSync(configPath, initial.replace(/\n/g, '\r\n'));
+
+    writeCodexMcpServer(configPath, 'ohno', {
+      command: 'npx',
+      args: ['@stevestomp/ohno-mcp'],
+    });
+
+    const result = readFileSync(configPath, 'utf8');
+    const occurrences = (result.match(/\[mcp_servers\.ohno\]/g) || []).length;
+    assert.equal(occurrences, 1, 'CRLF input should not produce a duplicate section');
+    assert.match(result, /args = \["@stevestomp\/ohno-mcp"\]/);
+    console.log('  PASS: CRLF-encoded section is upserted in place');
+  } finally {
+    rmSync(crlfDir, { recursive: true, force: true });
+  }
+}
 
 console.log('');
 console.log('All CLI dual-runtime tests passed!');

--- a/plugins/pokayokay/tests/codex-compatibility.test.sh
+++ b/plugins/pokayokay/tests/codex-compatibility.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Validate the Codex plugin surface exists without removing Claude support.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+PLUGIN="$ROOT/plugins/pokayokay"
+
+echo "Testing Codex compatibility files..."
+
+echo "Test 1: Claude manifest is still present"
+if [[ -f "$PLUGIN/.claude-plugin/plugin.json" ]]; then
+  echo "  PASS: Claude manifest remains"
+else
+  echo "  FAIL: Claude manifest missing"
+  exit 1
+fi
+
+echo "Test 2: Codex manifest exists and points at shared skills/MCP"
+CODEX_MANIFEST="$PLUGIN/.codex-plugin/plugin.json"
+if [[ ! -f "$CODEX_MANIFEST" ]]; then
+  echo "  FAIL: Codex manifest missing"
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (manifest.name !== "pokayokay") throw new Error("unexpected manifest name");
+if (manifest.skills !== "./skills/") throw new Error("skills path missing");
+if (manifest.mcpServers !== "./.mcp.json") throw new Error("mcpServers path missing");
+if (!manifest.interface || manifest.interface.displayName !== "Pokayokay") throw new Error("interface metadata missing");
+' "$CODEX_MANIFEST"
+echo "  PASS: Codex manifest parses"
+
+echo "Test 3: ohno MCP config exists for plugin runtime"
+MCP_CONFIG="$PLUGIN/.mcp.json"
+if [[ ! -f "$MCP_CONFIG" ]]; then
+  echo "  FAIL: .mcp.json missing"
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const config = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const ohno = config.mcpServers && config.mcpServers.ohno;
+if (!ohno) throw new Error("ohno server missing");
+if (ohno.command !== "npx") throw new Error("ohno command should use npx");
+if (!ohno.args || !ohno.args.includes("@stevestomp/ohno-mcp")) throw new Error("ohno package missing");
+' "$MCP_CONFIG"
+echo "  PASS: ohno MCP config parses"
+
+echo "Test 4: Codex hook config calls bridge.py"
+HOOKS="$PLUGIN/hooks.json"
+if [[ ! -f "$HOOKS" ]]; then
+  echo "  FAIL: hooks.json missing"
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const hooks = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).hooks || {};
+const serialized = JSON.stringify(hooks);
+if (!serialized.includes("bridge.py")) throw new Error("bridge.py not referenced");
+if (!hooks.PostToolUse) throw new Error("PostToolUse hook missing");
+' "$HOOKS"
+echo "  PASS: Codex hooks config parses"
+
+echo ""
+echo "All Codex compatibility file tests passed!"


### PR DESCRIPTION
## Summary
- add Codex plugin manifest, ohno MCP config, and hook config alongside existing Claude plugin support
- extend the setup CLI to detect/configure Claude Code, Codex, or both without making Claude optional regressions
- normalize bridge hook payloads so existing Claude-style events and Codex-style aliases route through the same handlers
- update docs and add focused compatibility tests

## Verification
- bash plugins/pokayokay/tests/codex-compatibility.test.sh
- node plugins/pokayokay/tests/cli-dual-runtime.test.mjs
- bash plugins/pokayokay/tests/bridge-runtime-normalization.test.sh
- PYTHONPYCACHEPREFIX=/tmp/pokayokay-pyc python3 -m py_compile plugins/pokayokay/hooks/actions/bridge.py
- bash plugins/pokayokay/tests/wip-capture.test.sh
- bash plugins/pokayokay/tests/parallel-mode.test.sh
- node -e "import('./cli/src/index.js').then(() => import('./cli/src/doctor.js')).then(() => console.log('cli modules import'))"

## Notes
- Existing Claude support is preserved via the original .claude-plugin manifest, Claude install path, and legacy .claude fallback docs.
- Full shell-test loop still contains pre-existing unrelated failures in legacy tests with hardcoded local paths or stale expectations; focused regression tests above pass.