### PR TITLE
fix(hooks): argument-boundary matching in ref-size directory gate

### DIFF
--- a/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
+++ b/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
@@ -52,21 +52,26 @@ if [ -z "$FILES" ]; then
       # `git add <paths>`: gate reference files named in the command, either
       # by full path or via any parent directory (`git add skills/foo` stages
       # everything beneath it, so a contained ref file must be checked too).
-      # Over-matching only widens the size check, never skips it.
+      # Each probe must appear as a COMPLETE argument — bounded by start/
+      # whitespace/quote/`=` before and optional `/` plus whitespace/quote/end
+      # after — so `skills/demo-other` or a deeper sibling file under demo/
+      # never matches the demo/ probe (a false block would deadlock commits
+      # that don't stage the oversized ref at all).
       SCOPE="about-to-be-staged"
       CANDIDATES=$(list_working_tree_refs)
       NL=$'\n'
       FILES=""
+      B_PRE='(^|[[:space:]"'"'"'=])'
+      B_POST='/?([[:space:]"'"'"']|$)'
       while IFS= read -r candidate; do
         [ -n "$candidate" ] || continue
         probe="$candidate"
         while [ -n "$probe" ]; do
-          case "$GIT_COMMAND" in
-            *"$probe"*)
-              FILES="${FILES}${FILES:+$NL}${candidate}"
-              break
-              ;;
-          esac
+          esc=$(printf '%s' "$probe" | sed 's/[][\.*^$()+?{|]/\\&/g')
+          if printf '%s' "$GIT_COMMAND" | grep -qE "${B_PRE}${esc}${B_POST}"; then
+            FILES="${FILES}${FILES:+$NL}${candidate}"
+            break
+          fi
           parent="${probe%/*}"
           [ "$parent" = "$probe" ] && break
           probe="$parent"

--- a/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
+++ b/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
@@ -49,33 +49,43 @@ if [ -z "$FILES" ]; then
       SCOPE="about-to-be-staged"
       FILES=$(git diff --name-only --diff-filter=ACM 2>/dev/null | grep "$REF_PATTERN" || true)
     elif echo "$GIT_COMMAND" | grep -qE "$ADD_CMD"; then
-      # `git add <paths>`: gate reference files named in the command, either
-      # by full path or via any parent directory (`git add skills/foo` stages
-      # everything beneath it, so a contained ref file must be checked too).
-      # Each probe must appear as a COMPLETE argument — bounded by start/
-      # whitespace/quote/`=` before and optional `/` plus whitespace/quote/end
-      # after — so `skills/demo-other` or a deeper sibling file under demo/
-      # never matches the demo/ probe (a false block would deadlock commits
-      # that don't stage the oversized ref at all).
+      # `git add <pathspec>...`: gate reference files the add will stage.
+      # Extract the pathspec region of each `git add` (everything up to the
+      # next shell separator), tokenize it, and match candidates with bash
+      # glob semantics: a token gates a candidate when it names it exactly,
+      # names a parent directory, or glob-matches it (references/*.md).
+      # Scoping tokens to the add region keeps commit-message words from
+      # false-blocking, and `demo-other` never matches a demo/ candidate.
+      # Quoted pathspecs containing spaces are split — a known limitation.
       SCOPE="about-to-be-staged"
       CANDIDATES=$(list_working_tree_refs)
       NL=$'\n'
       FILES=""
-      B_PRE='(^|[[:space:]"'"'"'=])'
-      B_POST='/?([[:space:]"'"'"']|$)'
+      ADD_REGIONS=$(printf '%s' "$GIT_COMMAND" |
+        grep -oE 'git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*add[[:space:]][^;&|)]*' |
+        sed -E 's/^git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*add[[:space:]]//')
+      TOKENS=$(printf '%s\n' "$ADD_REGIONS" | tr ' \t' '\n\n')
       while IFS= read -r candidate; do
         [ -n "$candidate" ] || continue
-        probe="$candidate"
-        while [ -n "$probe" ]; do
-          esc=$(printf '%s' "$probe" | sed 's/[][\.*^$()+?{|]/\\&/g')
-          if printf '%s' "$GIT_COMMAND" | grep -qE "${B_PRE}${esc}${B_POST}"; then
-            FILES="${FILES}${FILES:+$NL}${candidate}"
+        matched=""
+        while IFS= read -r token; do
+          [ -n "$token" ] || continue
+          token="${token#\"}"; token="${token%\"}"
+          token="${token#\'}"; token="${token%\'}"
+          case "$token" in ''|-*) continue ;; esac
+          token="${token#./}"
+          token="${token%/}"
+          if [ "$token" = "." ] || [ -z "$token" ]; then
+            matched=1
             break
           fi
-          parent="${probe%/*}"
-          [ "$parent" = "$probe" ] && break
-          probe="$parent"
-        done
+          # Unquoted case patterns give glob matching without pathname
+          # expansion; $token/* additionally covers directory containment.
+          case "$candidate" in
+            $token|$token/*) matched=1; break ;;
+          esac
+        done <<< "$TOKENS"
+        [ -n "$matched" ] && FILES="${FILES}${FILES:+$NL}${candidate}"
       done <<< "$CANDIDATES"
     fi
     # Plain `git commit` of already-staged files: nothing relevant staged,

--- a/plugins/pokayokay/tests/pre-commit-blocking.test.sh
+++ b/plugins/pokayokay/tests/pre-commit-blocking.test.sh
@@ -149,6 +149,38 @@ SLASH_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugin
 assert_deny "$SLASH_OUTPUT"
 echo "  PASS: trailing-slash directory add gates the contained oversized reference"
 
+echo "Test 5h: glob pathspec selecting the oversized ref is blocked"
+GLOB_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo/references/*.md && git commit -m \"glob\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$GLOB_OUTPUT"
+echo "  PASS: glob pathspec matching the oversized reference is gated"
+
+echo "Test 5i: dot-relative directory add gates the contained ref"
+DOT_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add ./plugins/pokayokay/skills/demo && git commit -m \"dot\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$DOT_OUTPUT"
+echo "  PASS: ./-prefixed pathspec gates the contained oversized reference"
+
+echo "Test 5j: space-free shell separator still bounds the pathspec (dir add)"
+NOSPACE_DIR_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo&&git commit -m ref"},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$NOSPACE_DIR_OUTPUT"
+echo "  PASS: && without surrounding spaces still gates the directory add"
+
+echo "Test 5k: space-free separator does not swallow the commit word into the path"
+# `git add <file>;git commit` — the ; must terminate the pathspec so the ref
+# is still matched by exact path, not merged with the trailing command.
+NOSPACE_FILE_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo/references/big-ref.md;git commit -m ref"},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$NOSPACE_FILE_OUTPUT"
+echo "  PASS: ;-separated file add is gated"
+
+echo "Test 5l: glob under a sibling directory does not false-block"
+SIBLING_GLOB_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo-other/*.md && git commit -m \"sibglob\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_not_blocked "$SIBLING_GLOB_OUTPUT"
+echo "  PASS: glob under demo-other does not match the demo/ reference"
+
 echo "Test 6: advisory failures (lint exit 1) do not block the commit"
 # Remove the violation entirely and stage a package.json whose lint fails.
 rm -f "$REF_DIR/big-ref.md"

--- a/plugins/pokayokay/tests/pre-commit-blocking.test.sh
+++ b/plugins/pokayokay/tests/pre-commit-blocking.test.sh
@@ -131,6 +131,24 @@ DIR_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/
 assert_deny "$DIR_OUTPUT"
 echo "  PASS: directory add gates the contained oversized reference"
 
+echo "Test 5e: sibling directory with shared prefix does not false-block"
+SIBLING_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo-other && git commit -m \"sib\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_not_blocked "$SIBLING_OUTPUT"
+echo "  PASS: demo-other add does not match the demo/ probe"
+
+echo "Test 5f: adding a different file under references/ does not false-block"
+OTHERFILE_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo/references/other.md && git commit -m \"other\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_not_blocked "$OTHERFILE_OUTPUT"
+echo "  PASS: sibling file add does not gate the unrelated oversized ref"
+
+echo "Test 5g: trailing-slash directory add still gates the contained ref"
+SLASH_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add plugins/pokayokay/skills/demo/ && git commit -m \"dirslash\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$SLASH_OUTPUT"
+echo "  PASS: trailing-slash directory add gates the contained oversized reference"
+
 echo "Test 6: advisory failures (lint exit 1) do not block the commit"
 # Remove the violation entirely and stage a package.json whose lint fails.
 rm -f "$REF_DIR/big-ref.md"


### PR DESCRIPTION
## Summary
Follow-up to #13's Codex review fixes. The parent-directory matching added for `git add <dir> && git commit` used bare substring containment, so:
- `git add plugins/pokayokay/skills/demo-other` matched the `…/skills/demo` probe → false block of a commit that never stages the oversized ref under `demo/`
- shallow probes (`plugins`) could match anywhere in the command text, including messages

Probes must now appear as complete arguments: bounded by start/whitespace/quote/`=` before and optional trailing `/` plus whitespace/quote/end after. Deeper sibling files (`…/demo/references/other.md`) no longer match the `demo` probe either.

## Test plan
- [x] New regression tests 5e (shared-prefix sibling dir → not blocked), 5f (sibling file under references/ → not blocked), 5g (trailing-slash dir add → blocked)
- [x] Existing 5/5b/5c/5d behavior unchanged
- [x] Full suite green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)