### PR TITLE
fix: review-pipeline verdicts, work.md split, skills purge, ref-size false-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pre-validated approach infeasible.
 - **Test runner + CI** — `tests/run-tests.sh` runs the full shell test suite
   in one command, and a CI workflow runs it on every push.
+- **Machine-parseable review verdicts** — reviewer agents now emit a
+  `VERDICT:` terminal line, and bridge.py parses it robustly (including a
+  `BLOCKED` verdict path) instead of relying on free-form prose.
+- **Dispatch-failure protocol** — four failure classes with a retry-once
+  policy and a `set_blocker` fallback when the retry also fails, plus a
+  one-shot brainstormer dispatch (no open-ended re-brainstorm loops).
+- **Structured parallel-conflict detection** — implementer handoffs report
+  `packages_touched`, which the coordinator unions with the existing
+  file-overlap heuristic when deciding what can run in parallel.
+- **work.md structure tests** — new tests pin the progressive-disclosure
+  extraction and the plugin-qualified dispatch-ID doc contract.
 
 ### Changed
 - **Agent model policy alignment** — agents now follow explicit model tiers:
@@ -23,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   domain reference files removed, `disable-model-invocation` on process
   skills, `allowed-tools` on read-only skills, CSO trigger-style descriptions
   and "When NOT to Use" sections.
+- **Coordinator-supplied review baseline** — reviewers receive an explicit
+  `BASE_COMMIT` from the coordinator and review the working tree against it
+  (working-tree-inclusive diff), with closed `BLOCKED` triggers and
+  mode-aware escalation instead of guessing a baseline.
+- **work.md progressive disclosure** — chain-state details and kaizen
+  review-failure handling extracted to `chain-state.md` and
+  `kaizen-review-failures.md` references, and the duplicated brainstorm-gate
+  text deduplicated, keeping work.md lean.
+- **Spike skill canonicalization** — spike time-box values, report paths, and
+  the decision enum are now canonical and consistent across the skill and its
+  references.
 
 ### Fixed
 - **Hook payload and routing repair** — bridge.py now parses MCP content-block
@@ -36,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suite passes again.
 - **CLI codex and Windows fixes** — corrected Codex install handling and
   Windows path issues in the setup wizard.
+- **Stale pre-ohno references removed** — remaining mentions of the old
+  `tasks.db` / `features.json` state files and dead skill routes are gone;
+  everything now points at ohno-backed task state.
+- **session-review allowed-tools completed** — the session-review skill's
+  `allowed-tools` list now includes every tool the workflow actually uses.
 
 ### Documentation
 - **Hook documentation truth pass** — hook docs (CLAUDE.md flow diagram and

--- a/plugins/pokayokay/agents/templates/implementer-prompt.md
+++ b/plugins/pokayokay/agents/templates/implementer-prompt.md
@@ -53,6 +53,7 @@ All file paths should be relative to this directory unless specified otherwise.
 
 ## Your Instructions
 
+0. **Record your base commit** - Run `git rev-parse HEAD` before any edit and keep the hash for your completion report (the coordinator cross-checks it against its own recorded baseline for the reviewers' diffs)
 1. **Review the task** - Read the description and acceptance criteria carefully
 2. **Ask questions if unclear** - Do NOT proceed with ambiguous requirements
 3. **Parse acceptance criteria** - Identify all MUST, SHOULD, and COULD criteria
@@ -89,12 +90,13 @@ When you complete implementation, report back using this minimal format — it m
 **Task**: {TASK_TITLE}
 **Status**: PASS | FAIL | BLOCKED | NEEDS_REDESIGN
 **Summary**: [2-3 sentence summary of what was done]
+**Base commit**: [hash recorded in step 0, before your first edit]
 **Commit**: [hash, if applicable]
 
 Full details stored in ohno handoff.
 ```
 
-Full details — including the acceptance criteria verification table (criterion, test file:line, status) — belong in the ohno handoff `details` field, not in the report.
+Full details — including the acceptance criteria verification table (criterion, test file:line, status) — belong in the ohno handoff `details` field, not in the report. Include the base commit in the handoff too, so the coordinator can cross-check its recorded `BASE_COMMIT`.
 
 ---
 

--- a/plugins/pokayokay/agents/templates/quality-review-prompt.md
+++ b/plugins/pokayokay/agents/templates/quality-review-prompt.md
@@ -9,6 +9,12 @@ You are being dispatched to review code quality. Spec compliance has already bee
 **Task ID**: {TASK_ID}
 **Title**: {TASK_TITLE}
 
+### Acceptance Criteria
+
+{ACCEPTANCE_CRITERIA}
+
+> For the Test-AC Mapping check only — do NOT re-verify spec compliance against these.
+
 ### Files Changed
 
 {FILES_CHANGED}
@@ -37,12 +43,18 @@ Review the implementation for:
 ### Review Commands
 
 ```bash
-# View the changes
-git diff {COMMIT_HASH}~1..{COMMIT_HASH}
+# View the changes (the diff against the base commit includes uncommitted
+# working-tree edits — post-fixer runs always have them)
+git diff {BASE_COMMIT}
+git status --porcelain
 
 # Check for test files
-git diff {COMMIT_HASH}~1..{COMMIT_HASH} --name-only | grep -E '\.(test|spec)\.'
+git diff {BASE_COMMIT} --name-only | grep -E '\.(test|spec)\.'
 ```
+
+**Base Commit**: {BASE_COMMIT}
+
+> `{BASE_COMMIT}` was recorded by the coordinator immediately before the implementer was dispatched — it is your primary diff baseline. If it is missing, fall back per your agent definition (merge-base with the default branch, then `HEAD~1`) and state which baseline you used.
 
 **Working Directory**: {WORKING_DIRECTORY}
 
@@ -53,7 +65,8 @@ git diff {COMMIT_HASH}~1..{COMMIT_HASH} --name-only | grep -E '\.(test|spec)\.'
 - **Don't re-check spec**: Spec compliance already verified
 - **Be specific**: Cite files, lines, and specific issues
 - **Don't nitpick**: Style preferences are suggestions, not failures
-- **Binary verdict**: PASS or FAIL only
+- **Verdict**: PASS or FAIL; BLOCKED only under the enumerated cannot-review conditions (zero changes, no acceptance criteria, nonexistent commit, declared checks fail to launch)
+- **Terminal line**: End your reply with a final line exactly `VERDICT: PASS`, `VERDICT: FAIL`, or `VERDICT: BLOCKED`
 
 ---
 
@@ -61,9 +74,13 @@ git diff {COMMIT_HASH}~1..{COMMIT_HASH} --name-only | grep -E '\.(test|spec)\.'
 
 Variables:
 - {TASK_ID}, {TASK_TITLE}: From ohno task
+- {ACCEPTANCE_CRITERIA}: From ohno task (post-brainstorm) — input for the
+  Test-AC Mapping check; without it the reviewer's cannot-review trigger (b)
+  would fire on every quality review
 - {FILES_CHANGED}: From implementer handoff / git diff --name-only
 - {COMMIT_INFO}: Implementer's commit (hash + message)
-- {COMMIT_HASH}: Bare commit hash for the git diff verification commands
+- {BASE_COMMIT}: Recorded by the coordinator at implementer dispatch
+  (work.md Step 4) — primary diff baseline, includes working-tree edits
 - {APPROACH}: The design reviewer's approved approach (work.md Step 3.7).
   Fill with "None — design review was skipped" when the gate was skipped
   (/fix and /hotfix pipelines never run design review).

--- a/plugins/pokayokay/agents/templates/spec-review-prompt.md
+++ b/plugins/pokayokay/agents/templates/spec-review-prompt.md
@@ -39,11 +39,15 @@ You are being dispatched to verify that an implementation matches its specificat
 
 ## Your Assignment
 
-1. Read the actual code changes (`git diff {COMMIT_HASH}~1..{COMMIT_HASH}`)
+1. Read the actual code changes (`git diff {BASE_COMMIT}` plus `git status --porcelain` — the diff against the base commit includes uncommitted working-tree edits, which post-fixer runs always have since the fixer does not commit)
 2. Check each acceptance criterion against the code (not the summary)
 3. Look for missing requirements
 4. Look for scope creep (unrequested additions)
-5. Return PASS or FAIL
+5. Return PASS or FAIL (BLOCKED only under your enumerated cannot-review conditions), ending with the terminal `VERDICT:` line
+
+**Base Commit**: {BASE_COMMIT}
+
+> `{BASE_COMMIT}` was recorded by the coordinator immediately before the implementer was dispatched — it is your primary diff baseline. If it is missing, fall back per your agent definition (merge-base with the default branch, then `HEAD~1`) and state which baseline you used.
 
 **Working Directory**: {WORKING_DIRECTORY}
 
@@ -54,4 +58,5 @@ You are being dispatched to verify that an implementation matches its specificat
 - **Adversarial**: Don't trust the implementer's report
 - **Evidence-based**: Cite files and lines for each criterion
 - **Scope discipline**: Extra work is also a failure
-- **Binary verdict**: PASS or FAIL only
+- **Verdict**: PASS or FAIL; BLOCKED only under the enumerated cannot-review conditions (zero changes, no acceptance criteria, nonexistent commit)
+- **Terminal line**: End your reply with a final line exactly `VERDICT: PASS`, `VERDICT: FAIL`, or `VERDICT: BLOCKED`

--- a/plugins/pokayokay/agents/yokay-brainstormer.md
+++ b/plugins/pokayokay/agents/yokay-brainstormer.md
@@ -123,9 +123,9 @@ When multiple approaches are plausible, present them before the criteria:
 3. Conservative fallback: [approach] — [when to choose it]
 ```
 
-### 5. Request Confirmation
+### 5. Report Results
 
-Present your refined requirements and ask for confirmation:
+Present your refined requirements in your final report:
 
 ```markdown
 ## Brainstorm Complete
@@ -136,7 +136,7 @@ Present your refined requirements and ask for confirmation:
 
 [Your proposed acceptance criteria]
 
-### Questions for Coordinator
+### Open Questions
 
 [Ask the single most important remaining question. If there are several,
 state that more questions may follow after this answer.]
@@ -144,11 +144,11 @@ state that more questions may follow after this answer.]
 ### Recommendation
 
 [Your recommended approach]
-
----
-
-Please confirm these requirements or provide corrections.
 ```
+
+You are one-shot: never wait for a reply. Return `Status: Refined` with
+proposed criteria, or `Status: Needs Input` with questions under
+`### Open Questions`; the coordinator re-dispatches with answers.
 
 ## Output Contract
 
@@ -242,6 +242,8 @@ If after exploration you still can't clarify requirements:
 
 ### What I Need
 [Information required to proceed]
-
-Awaiting human input before continuing.
 ```
+
+You are one-shot: never wait for a reply. Return this escalation as your final
+report with `Status: Needs Input` and your questions under `### Open Questions`;
+the coordinator re-dispatches with answers.

--- a/plugins/pokayokay/agents/yokay-quality-reviewer.md
+++ b/plugins/pokayokay/agents/yokay-quality-reviewer.md
@@ -73,13 +73,31 @@ If the dispatch prompt provides no pre-validated approach (`None — design revi
 ## Review Process
 
 ```bash
-# Read the changes
-git diff HEAD~1 --name-only
-git diff HEAD~1
+# Read the changes. {BASE_COMMIT} is recorded by the coordinator before the
+# implementer was dispatched; diffing against it includes uncommitted
+# working-tree edits (post-fixer runs always have them — the fixer does not commit).
+git diff {BASE_COMMIT} --name-only
+git diff {BASE_COMMIT}
+git status --porcelain
 
 # Check existing patterns in the codebase for comparison
 # Look at similar files to verify convention compliance
 ```
+
+**Baseline fallback**: If `{BASE_COMMIT}` was not provided, use `git merge-base HEAD <default-branch>` (detect the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `main`/`master`); if that fails too, use `HEAD~1`. State in your report which baseline you used.
+
+If the diff range contains commits from other tasks (parallel or in-place mode), restrict your review to the files in the dispatch prompt's FILES_CHANGED list.
+
+## When You Cannot Review
+
+Exactly these conditions justify a BLOCKED verdict:
+
+- (a) The diff range resolves to zero changes
+- (b) No acceptance criteria are present in the dispatch prompt
+- (c) The provided commit hash does not exist
+- (d) The project's declared checks (package.json scripts, Makefile targets) fail to launch
+
+For exactly these conditions and no others, return BLOCKED. BLOCKED is for cannot-review, never hard-to-review. Trigger (d) applies only when the project actually declares such checks — if a project has no test/lint toolchain, that is not BLOCKED: state why the check was not available (per Critical Rules) and review what you can.
 
 ## Automated Checks (Run Before Code Review)
 
@@ -89,10 +107,16 @@ Before reading the code, run these checks. Note results in your output.
 
 ```bash
 # Get changed source files (exclude tests)
-CHANGED=$(git diff HEAD~1 --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx|py)$' | grep -v '\.test\.\|\.spec\.')
+CHANGED=$(git diff {BASE_COMMIT} --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx|py)$' | grep -v '\.test\.\|\.spec\.')
 
-# Run tests with coverage (adapt to project)
-npm test -- --coverage --changedSince=HEAD~1 2>/dev/null || npx vitest run --coverage 2>/dev/null
+# Run tests with coverage (adapt to project). Run the candidates as SEPARATE
+# commands — never chain with `||` — so launch failures and stderr stay
+# visible, and capture each exit code explicitly.
+npm test -- --coverage 2>&1 | tail -40
+echo "npm-test exit=${PIPESTATUS[0]}"
+
+npx vitest run --coverage 2>&1 | tail -40
+echo "vitest exit=${PIPESTATUS[0]}"
 ```
 
 If branch coverage on any touched source file is below 80%, note as Warning.
@@ -100,20 +124,26 @@ If branch coverage on any touched source file is below 80%, note as Warning.
 ### 2. Lint and Type Check
 
 ```bash
-# Lint changed files
-npx eslint $(git diff HEAD~1 --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx)$') 2>/dev/null
+# Lint changed files (keep stderr visible; capture the exit code)
+npx eslint $(git diff {BASE_COMMIT} --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx)$') 2>&1
+echo "eslint exit=$?"
 
 # Type check
-npx tsc --noEmit 2>/dev/null
+npx tsc --noEmit 2>&1 | tail -40
+echo "tsc exit=${PIPESTATUS[0]}"
 ```
 
-New lint warnings or type errors in changed files = Warning.
+New lint warnings = Warning. Type errors in changed files = Major (FAIL); pre-existing type errors outside changed files = Warning.
 
 ### 3. Test-AC Mapping
 
-Read the task's acceptance criteria. For each MUST criterion, verify a test exists with a name or comment referencing that criterion. Missing mappings = Warning.
+Read the acceptance criteria from the dispatch prompt. For each MUST criterion, verify a test exists with a name or comment referencing that criterion. Missing name/comment mappings = Warning; a MUST criterion with no test at all = Major (FAIL).
 
 ## Output Contract
+
+### Terminal Verdict Line (Required)
+
+The LAST non-empty line of your reply MUST be exactly `VERDICT: PASS`, `VERDICT: FAIL`, or `VERDICT: BLOCKED` on its own line. Never write the string `VERDICT:` anywhere else in your reply — the coordinator branches on the last occurrence.
 
 ### PASS
 
@@ -136,7 +166,9 @@ Code is well-structured, tested, and follows project conventions.
 ### Verification Evidence
 
 - Command(s): [fresh checks run]
-- Result: [PASS/FAIL, exit status, relevant counts]
+- Result: [exit status and relevant counts, e.g. "exit 0, 42 tests passed"]
+
+VERDICT: PASS
 ```
 
 ### FAIL
@@ -156,6 +188,24 @@ Code is well-structured, tested, and follows project conventions.
 ### Required Fixes
 1. [Specific fix needed]
 2. [Specific fix needed]
+
+VERDICT: FAIL
+```
+
+### BLOCKED
+
+Only for the enumerated cannot-review conditions:
+
+```markdown
+## Quality Review: BLOCKED
+
+**Task**: {task_title}
+
+**Condition**: [(a) zero changes / (b) no acceptance criteria / (c) commit hash does not exist / (d) declared checks fail to launch]
+**Evidence**: [command output or the missing dispatch-prompt section]
+**Needed from coordinator**: [the specific input that would let the review run]
+
+VERDICT: BLOCKED
 ```
 
 ## Severity Guide
@@ -163,15 +213,16 @@ Code is well-structured, tested, and follows project conventions.
 | Level | Examples | Action |
 |-------|----------|--------|
 | Critical | Security issue, data loss risk, crash | FAIL |
-| Warning | Bug, logic error, missing tests, code smell | FAIL |
-| Warning | Deviated from approach without escalating | FAIL |
+| Major | Bug, logic error, missing test for a MUST criterion, type error in a changed file, serious code smell | FAIL |
+| Major | Deviated from the pre-validated approach without escalating NEEDS_REDESIGN | FAIL |
+| Warning | Advisory, recorded but non-failing: branch coverage <80% on a touched file, new lint warnings, missing AC-name test mapping, pre-existing type errors outside changed files | Note but PASS |
 | Suggestion | Better pattern, minor style issue | Note but PASS |
 
-**Only FAIL for Critical or Warning issues.**
+**Only FAIL for Critical or Major issues.** Warnings are recorded in the output but never fail the review on their own. Type errors are reported (and fail) only for changed files.
 
 ## Guidelines
 
-1. **Binary verdict**: PASS or FAIL only
+1. **Verdict**: PASS or FAIL, ending with the terminal `VERDICT:` line; BLOCKED only under the enumerated cannot-review conditions
 2. **Don't re-check spec**: Spec compliance is already verified
 3. **Be specific**: Cite exact files, lines, and issues
 4. **Don't nitpick**: Style preferences are suggestions, not failures

--- a/plugins/pokayokay/agents/yokay-reviewer.md
+++ b/plugins/pokayokay/agents/yokay-reviewer.md
@@ -28,13 +28,16 @@ You are a thorough code reviewer focused on quality, security, and maintainabili
 ### 1. Identify Changes
 
 ```bash
-# Recent changes
-git diff HEAD~1 --name-only
+# Recent changes (BASE_COMMIT is supplied by the coordinator when dispatched
+# from a work session; see fallback below when reviewing ad hoc)
+git diff {BASE_COMMIT} --name-only
 git diff --cached --name-only
 
 # Full diff
-git diff HEAD~1
+git diff {BASE_COMMIT}
 ```
+
+**Baseline fallback**: If `{BASE_COMMIT}` was not provided, use `git merge-base HEAD <default-branch>` (detect the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `main`/`master`); if that fails too, use `HEAD~1`. State in your report which baseline you used.
 
 ### 2. Analyze Changed Files
 
@@ -128,8 +131,14 @@ For each changed file:
 
 ## Overall Assessment
 
-[Pass/Fail/Conditional Pass with summary]
+[Pass or Fail with summary. There is no conditional pass: a review that
+would previously have been a "conditional pass" is a PASS whose conditions
+are listed in the Warnings section.]
+
+VERDICT: [PASS or FAIL]
 ```
+
+The LAST non-empty line of your reply MUST be exactly `VERDICT: PASS` or `VERDICT: FAIL` on its own line. Never write the string `VERDICT:` anywhere else in your reply.
 
 ## Security Checklist
 

--- a/plugins/pokayokay/agents/yokay-spec-reviewer.md
+++ b/plugins/pokayokay/agents/yokay-spec-reviewer.md
@@ -79,13 +79,31 @@ A task that produces files referencing APIs, components, or schemas that don't e
 ## Review Process
 
 ```bash
-# Get the actual changes — this is your source of truth
-git diff HEAD~1 --name-only
-git diff HEAD~1
+# Get the actual changes — this is your source of truth.
+# {BASE_COMMIT} is recorded by the coordinator before the implementer was
+# dispatched; diffing against it includes uncommitted working-tree edits
+# (post-fixer runs always have them — the fixer does not commit).
+git diff {BASE_COMMIT} --name-only
+git diff {BASE_COMMIT}
+git status --porcelain
 
 # Read each changed file fully
 # Compare against acceptance criteria
 ```
+
+**Baseline fallback**: If `{BASE_COMMIT}` was not provided, use `git merge-base HEAD <default-branch>` (detect the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `main`/`master`); if that fails too, use `HEAD~1`. State in your report which baseline you used.
+
+If the diff range contains commits from other tasks (parallel or in-place mode), restrict your review to the files in the dispatch prompt's FILES_CHANGED list.
+
+## When You Cannot Review
+
+Exactly these conditions justify a BLOCKED verdict:
+
+- (a) The diff range resolves to zero changes
+- (b) No acceptance criteria are present in the dispatch prompt
+- (c) The provided commit hash does not exist
+
+For exactly these conditions and no others, return BLOCKED. BLOCKED is for cannot-review, never hard-to-review.
 
 ## Output Contract
 
@@ -102,13 +120,18 @@ For EVERY acceptance criterion in the task, produce an evidence row:
 | 2 | MUST | error | [criterion text] | FAIL | No test found. Implementation exists but untested. |
 | 3 | SHOULD | edge-case | [criterion text] | SKIP | Not implemented. Justification: "deferred to i18n story" |
 
-### Verdict: PASS / FAIL
+### Verdict
+[PASS or FAIL]
 
 **Rules:**
 - MUST criterion with FAIL → overall FAIL
 - SHOULD criterion with SKIP but no justification → overall FAIL
 - COULD criteria don't affect verdict
 ```
+
+### Terminal Verdict Line (Required)
+
+The LAST non-empty line of your reply MUST be exactly `VERDICT: PASS`, `VERDICT: FAIL`, or `VERDICT: BLOCKED` on its own line. Never write the string `VERDICT:` anywhere else in your reply — the coordinator branches on the last occurrence.
 
 ### PASS
 
@@ -124,6 +147,8 @@ All MUST criteria met with evidence. No unjustified SHOULD skips.
 | 3 | SHOULD | edge-case | Unicode in name fields | SKIP | Justified: "deferred to i18n story" |
 
 No missing requirements. No scope creep.
+
+VERDICT: PASS
 ```
 
 ### FAIL
@@ -141,11 +166,27 @@ No missing requirements. No scope creep.
 ### Required Fixes
 1. Add test for duplicate email → 409 response
 2. Update handler to catch unique constraint violation and return 409
+
+VERDICT: FAIL
+```
+
+### BLOCKED
+
+Only for the enumerated cannot-review conditions:
+
+```markdown
+## Spec Review: BLOCKED
+
+**Condition**: [(a) zero changes / (b) no acceptance criteria / (c) commit hash does not exist]
+**Evidence**: [command output or the missing dispatch-prompt section]
+**Needed from coordinator**: [the specific input that would let the review run]
+
+VERDICT: BLOCKED
 ```
 
 ## Guidelines
 
-1. **Binary verdict**: PASS or FAIL only
+1. **Verdict**: PASS or FAIL, ending with the terminal `VERDICT:` line; BLOCKED only under the enumerated cannot-review conditions
 2. **Evidence-based**: Every PASS needs file:line for BOTH test and implementation. No evidence = FAIL.
 3. **Don't assess quality**: That's the quality reviewer's job
 4. **Extra work = FAIL**: Scope creep is a spec compliance issue

--- a/plugins/pokayokay/agents/yokay-spike-runner.md
+++ b/plugins/pokayokay/agents/yokay-spike-runner.md
@@ -133,7 +133,7 @@ Write to `.claude/spikes/[date]-[slug].md`:
 - [Issue 2]
 
 ### Proof of Concept
-Location: `.claude/spikes/[name]/`
+Location: `.claude/spikes/[date]-[slug]/`
 ```[language]
 [Key code sample]
 ```

--- a/plugins/pokayokay/agents/yokay-spike-runner.md
+++ b/plugins/pokayokay/agents/yokay-spike-runner.md
@@ -21,7 +21,7 @@ You execute time-boxed technical investigations to reduce uncertainty. Your job 
 
 - NEVER produce production code. Spike code is throwaway.
 - NEVER exceed the time-box without reporting back.
-- NEVER conclude without a clear recommendation (GO/NO-GO/CONDITIONAL).
+- NEVER conclude without a clear recommendation (GO/NO-GO/PIVOT/MORE-INFO).
 
 ## Spike Philosophy
 
@@ -31,7 +31,7 @@ OUTPUT: Decision + proof → "Yes, with caveats. Here's the PoC."
 
 BOUNDED: 2-4 hours (never >1 day)
 FOCUSED: Answer ONE question
-DECISIVE: End with GO/NO-GO/PIVOT
+DECISIVE: End with GO/NO-GO/PIVOT/MORE-INFO
 ```
 
 ## Spike Types
@@ -106,7 +106,7 @@ Every spike MUST end with ONE of:
 
 ## Output Contract
 
-Write to `.claude/spikes/[name]-[date].md`:
+Write to `.claude/spikes/[date]-[slug].md`:
 
 ```markdown
 # Spike Report: [Title]
@@ -149,6 +149,20 @@ Location: `.claude/spikes/[name]/`
 - [Time]: [Activity]
 ```
 
+### Return to Coordinator
+
+Your final message back to the coordinator MUST contain:
+
+- **Decision**: one of GO / NO-GO / PIVOT / MORE-INFO
+- **Answer**: direct answer to the spike question in 1-2 sentences
+- **Report path**: `.claude/spikes/[date]-[slug].md`
+
+End the message with this exact line format:
+
+```
+DECISION: GO|NO-GO|PIVOT|MORE-INFO
+```
+
 ## Anti-Patterns to Avoid
 
 | Anti-Pattern | Problem | Fix |
@@ -157,13 +171,13 @@ Location: `.claude/spikes/[name]/`
 | No time box | Investigation never ends | Set 2-4h limit |
 | Scope creep | "While I'm here..." | Stay on question |
 | No checkpoints | Realize late you're stuck | Check at 25/50/75% |
-| No decision | "It depends" | Force GO/NO-GO/PIVOT |
+| No decision | "It depends" | Force GO/NO-GO/PIVOT/MORE-INFO |
 | Building too much | Full implementation | PoC only |
 
 ## Guidelines
 
 1. **Time-box strictly**: Stop at the limit even if incomplete
-2. **Decide decisively**: No "maybe" - pick GO/NO-GO/PIVOT
+2. **Decide decisively**: No "maybe" - pick GO/NO-GO/PIVOT/MORE-INFO
 3. **Document everything**: Knowledge captured even if NO-GO
 4. **Stay focused**: One question, one answer
 5. **Write the report**: Output to `.claude/spikes/` for future reference

--- a/plugins/pokayokay/commands/plan.md
+++ b/plugins/pokayokay/commands/plan.md
@@ -155,6 +155,12 @@ mcp__ohno__create_task:
   description: "<rich description per Section 4.5>"
 ```
 
+When the planner JSON provides `packages_touched` for a task (`stories[].tasks[]`
+only — `spikes[]` and design tasks lack the field), append a final description
+line in the exact form `Packages: <comma-separated packages_touched>` (e.g.
+`Packages: @sakeba/api, apps/web`). This line is machine-parsed by `/work`
+for parallel-dispatch conflict detection — see Section 4.5.
+
 #### 4.4 Add Dependencies
 Link tasks that depend on each other:
 ```
@@ -229,6 +235,8 @@ mcp__ohno__create_task:
 
     Patterns to Follow:
     - Follow existing endpoint patterns in src/routes/
+
+    Packages: @app/api
 ```
 
 Every task description MUST include:
@@ -237,6 +245,7 @@ Every task description MUST include:
 3. **Acceptance criteria**: 3-5 checkboxes the implementer can self-verify against
 4. **Connects To**: Which tasks this depends on and blocks, with brief context
 5. **Patterns to Follow**: Where to look for conventions in existing code
+6. **Packages** (when the planner JSON provides `packages_touched` — `stories[].tasks[]` only): a final line in the exact form `Packages: <comma-separated packages_touched>` (e.g. `Packages: @sakeba/api, apps/web`). This line is machine-parsed by `/work` — its parallel-dispatch conflict check never batches two tasks sharing a package. Omit it for spike and design tasks, which lack the field.
 
 #### Anti-Pattern: Vague Descriptions
 

--- a/plugins/pokayokay/commands/work.md
+++ b/plugins/pokayokay/commands/work.md
@@ -50,105 +50,13 @@ Example arguments:
 ## Headless Configuration
 
 Headless mode enables automatic session chaining when context fills up.
+Configuration lives in `.pokayokay/config.json` (fallback:
+`.claude/pokayokay.json`), and headless/auto/unattended sessions REQUIRE an
+explicit scope (`--epic`, `--story`, or `--all`) to prevent runaway sessions —
+PAUSE and ask for one if none is given.
 
-### Configuration
-
-Read headless config from `.pokayokay/config.json` when present, falling back to `.claude/pokayokay.json` for existing Claude Code projects:
-
-```json
-{
-  "headless": {
-    "max_chains": 10,
-    "report": "on_complete",
-    "notify": "terminal"
-  }
-}
-```
-
-| Setting | Values | Default | Description |
-|---------|--------|---------|-------------|
-| `max_chains` | 1-50 | 10 | Maximum sessions to chain before stopping |
-| `report` | `on_complete`, `on_failure`, `always`, `never` | `on_complete` | When to generate chain report |
-| `notify` | `terminal`, `none` | `terminal` | How to notify on chain completion |
-
-### Scope Requirement
-
-**Headless mode requires explicit scope to prevent runaway sessions.**
-
-When running headless (auto/unattended mode or `--continue` from chain):
-- `--epic <id>`: Only work on tasks within the specified epic
-- `--story <id>`: Only work on tasks within the specified story
-- `--all`: Explicitly allow working on all available tasks
-
-If no scope is provided in auto/unattended/headless mode, PAUSE and ask:
-```markdown
-Headless/auto/unattended mode requires a scope to prevent runaway sessions.
-
-Which tasks should this session work on?
-  1. --epic <id>  (work within a specific epic)
-  2. --story <id> (work within a specific story)
-  3. --all        (all available tasks)
-```
-
-### Scope Filtering
-
-When scope is set, filter `get_next_task` and `get_next_batch` results:
-
-```python
-def get_scoped_tasks(scope):
-    if scope.type == "epic":
-        return get_tasks(epic_id=scope.id, status="todo")
-    elif scope.type == "story":
-        return get_tasks(story_id=scope.id, status="todo")  # via story filter
-    else:  # "all"
-        return get_next_batch()
-```
-
-### Session Chaining
-
-When a session reaches context limits:
-
-1. Save current WIP to ohno (automatic via hooks)
-2. Generate chain report if configured
-3. Exit with chain metadata:
-   ```json
-   {
-     "chain_id": "chain-abc123",
-     "chain_index": 3,
-     "max_chains": 10,
-     "scope": {"type": "epic", "id": "epic-abc123"},
-     "tasks_completed": 5,
-     "tasks_remaining": 8
-   }
-   ```
-4. SessionEnd hook spawns or prepares the next session using the active runtime:
-   ```bash
-   # Claude Code
-   claude -p "/work --continue --epic epic-abc123"
-
-   # Codex
-   codex --prompt="/work --continue --epic epic-abc123"
-   ```
-
-### Chain Reporting
-
-On chain completion (all tasks done or max_chains reached), generate report:
-
-```
-.ohno/reports/chain-{id}-report.md
-
-# Session Chain Report
-- Chain ID: chain-abc123
-- Sessions: 4
-- Scope: epic-4fcd1e3c (Context Efficiency Redesign)
-- Tasks completed: 12
-- Tasks failed: 1 (task-xyz: test failures)
-- Tasks remaining: 2
-- Total duration: ~45 minutes
-- Decisions made: [extracted from task handoffs]
-```
-
-Report is generated BEFORE memory decay compacts handoff details.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/chain-state.md` for
+the config schema, scope filtering, session chaining flow, and chain reporting.
 
 ## Adaptive Parallel Sizing
 
@@ -206,64 +114,15 @@ Parallel sizing: 3 → 2 (batch interrupted by context fill)
 
 ## Proactive Context Shutdown
 
-When session chaining is active (chain state file exists), the coordinator MUST
-proactively end the session when context pressure is detected — **before** quality
-degrades from repeated compaction.
+When session chaining is active (chain state file exists) and context pressure
+is detected (runtime compaction, context-limit reminders, repeated information
+loss), the coordinator MUST stop dispatching new tasks, let in-flight agents
+finish, save WIP and coordinator state to the chain state file, and end the
+session so the SessionEnd hook chains a fresh one. Non-chained
+(supervised/semi-auto) sessions do not proactively end — the user is present.
 
-### Detection
-
-Context pressure is detected when **any** of these occur:
-1. The active runtime compacts the conversation (for example, Claude Code shows "Compacting conversation..." in output)
-2. A system reminder mentions context limits
-3. You notice repeated information loss from prior context
-
-### Behavior
-
-When context pressure is detected during a chained session:
-
-1. **Stop dispatching new tasks** — do not start another batch
-2. **Wait for in-flight agents** — let current implementers finish (they have their own context)
-3. **Save WIP** for any incomplete work:
-   ```
-   For each in-progress task with uncommitted changes:
-     update_task_wip(task_id, { files_modified, last_commit, uncommitted_changes, next_step })
-   ```
-4. **Save coordinator state** to chain state file:
-   ```
-   Read existing .pokayokay/pokayokay-chain-state.json, falling back to .claude/pokayokay-chain-state.json
-   Update with:
-     adaptive_n: current parallel count
-     batches_completed: count
-     batches_failed: count
-     failed_tasks: [task IDs that failed/blocked]
-     conflict_tasks: [task IDs with git conflicts]
-     last_session_summary: "Completed X tasks, Y failed, Z conflicts"
-   Write back to .pokayokay/pokayokay-chain-state.json
-   ```
-5. **Log session summary**:
-   ```
-   add_task_activity(task_id, "note", "Session ending: context pressure detected, chaining to next session")
-   ```
-6. **End the session** — output a brief summary and stop. This triggers:
-   - SessionEnd hook → bridge.py reads chain state → session-chain.sh spawns/prepares the next runtime session
-
-### Why Proactive?
-
-Without proactive shutdown:
-- Context fills → Claude Code compacts → quality degrades → compacts again → eventually dies
-- Each compaction loses coordinator context (task state, batch tracking, decisions)
-- Subagents returning to a degraded coordinator get confused
-
-With proactive shutdown:
-- First compaction detected → graceful exit → fresh session chains with full context
-- No quality degradation
-- WIP preserved for seamless resume
-
-### Non-Chained Sessions
-
-In supervised or semi-auto sessions (no chain state file), compaction is handled
-normally by the active runtime. The coordinator does NOT need to proactively end — the user
-is present and can decide.
+Follow the shutdown steps in
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/chain-state.md`.
 
 ## Session Start
 
@@ -285,32 +144,14 @@ If mode is `auto` or `unattended` or `--continue` flag is set, verify scope:
 
 ### 1.5 Initialize Chain State (if auto/unattended + scope, NOT --continue)
 
-When starting a NEW auto or unattended session with scope (not `--continue`), write the chain state file
-so that SessionEnd hooks can spawn continuation sessions:
+When starting a NEW auto or unattended session with scope (not `--continue`),
+write `.pokayokay/pokayokay-chain-state.json` with the Write tool so that
+SessionEnd hooks can spawn continuation sessions. Skip this step when mode is
+supervised/semi-auto, when no scope is set, or when `--continue` is set (the
+state file already exists from the previous session).
 
-```
-Write .pokayokay/pokayokay-chain-state.json:
-{
-  "chain_id": "chain-<current-unix-timestamp>",
-  "chain_index": 0,
-  "scope_type": "<epic|story|all>",
-  "scope_id": "<id or empty string>",
-  "tasks_completed": 0,
-  "adaptive_n": 2,
-  "batches_completed": 0,
-  "batches_failed": 0,
-  "failed_tasks": [],
-  "conflict_tasks": [],
-  "last_session_summary": ""
-}
-```
-
-Use the Write tool. Generate chain_id from current unix timestamp.
-
-**Skip this step** if:
-- Mode is NOT auto/unattended (supervised/semi-auto don't chain)
-- No scope is set (chaining requires scope)
-- `--continue` flag is set (state file already exists from previous session)
+Use the JSON template in
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/chain-state.md`.
 
 ### 2. Get Session Context
 Use ohno MCP `get_session_context` to understand:
@@ -574,7 +415,33 @@ Coordinator maintains N concurrent implementers:
    - No unmet `blockedBy` dependencies
    - Not blocked by another task in active_agents
 
-2. **File conflict check**: Before dispatching, scan task descriptions for implicit file-level conflicts:
+2. **File conflict check**: Before dispatching, detect file-level conflicts between queued tasks. Run BOTH checks below on every queued task and UNION the conflict sets — a pair conflicts if either check flags it.
+
+   **Structured conflict check** (`Packages:` trailer): tasks created by `/plan` end their description with a machine-parsed `Packages:` line when the planner provided `packages_touched` (plan.md Section 4.5). Two tasks sharing a package never run in the same batch:
+
+   ```python
+   def detect_package_conflicts(tasks):
+       """Parse the structured 'Packages:' trailer written by /plan."""
+       import re
+       task_packages = {}  # task_id -> set of declared packages
+
+       for task in tasks:
+           m = re.search(r'^Packages:\s*(.+)$', task.description, re.MULTILINE)
+           if m:
+               task_packages[task.id] = {p.strip() for p in m.group(1).split(",") if p.strip()}
+
+       conflicts = []
+       task_ids = list(task_packages.keys())
+       for i in range(len(task_ids)):
+           for j in range(i + 1, len(task_ids)):
+               overlap = task_packages[task_ids[i]] & task_packages[task_ids[j]]
+               if overlap:
+                   conflicts.append((task_ids[i], task_ids[j], overlap))
+
+       return conflicts
+   ```
+
+   **Heuristic conflict check** (regex over title+description): runs on every queued task — including tasks with a `Packages:` line — and is the ONLY signal for tasks without one (created via `/quick`, `/fix`, `/hotfix`, or plans predating the trailer):
 
    ```python
    def detect_file_conflicts(tasks):
@@ -610,8 +477,12 @@ Coordinator maintains N concurrent implementers:
                    conflicts.append((task_ids[i], task_ids[j], overlap))
 
        return conflicts
+   ```
 
-   conflicts = detect_file_conflicts(queued_tasks)
+   **Union and defer**: merge both conflict sets, keep the first task of each conflicting pair, and defer the later task to the next batch:
+
+   ```python
+   conflicts = detect_package_conflicts(queued_tasks) + detect_file_conflicts(queued_tasks)
    if conflicts:
        # Serialize conflicting tasks, parallelize the rest
        # Keep first task in each conflict pair, defer second to next batch
@@ -649,6 +520,11 @@ Coordinator maintains N concurrent implementers:
 5. **Track state**: Add all dispatched tasks to `active_agents`
 
 #### Processing Results
+
+If a dispatch fails or returns a suspect report (tool error/timeout, empty or
+verdict-less report, questions-only, or success claimed without a commit),
+apply the Dispatch Failure Protocol in
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/dispatch-errors.md`.
 
 As each agent returns:
 
@@ -922,135 +798,18 @@ add_task_activity(task_id, "note", "Design plugin not available, user chose to c
 ### 3. Brainstorm Gate (Conditional)
 
 Before dispatching the implementer, check if the task needs brainstorming.
+The gate triggers on short descriptions (< 100 chars), missing or low-quality
+acceptance criteria, spike-type tasks, and ambiguous keywords ("investigate",
+"explore", "figure out", "look into", "research"); it is skipped for bug/chore
+tasks with AC that passes the quality check, or when `--skip-brainstorm` is set.
 
-#### Trigger Conditions
-
-Brainstorm triggers when ANY of these are true:
-
-| Condition | Check | Rationale |
-|-----------|-------|-----------|
-| Short description | `len(description) < 100 chars` | Likely underspecified |
-| No acceptance criteria | `acceptance_criteria is empty` | No clear success definition |
-| Spike type | `task_type == "spike"` | Investigation required |
-| Ambiguous keywords | Contains "investigate", "explore", "figure out" | Unclear scope |
-
-#### Skip Conditions
-
-Brainstorm is skipped when ANY of these are true:
-
-| Condition | Check | Rationale |
-|-----------|-------|-----------|
-| Bug type | `task_type == "bug"` | Usually well-defined |
-| Chore type | `task_type == "chore"` | Usually mechanical |
-| Well-specified | Has description AND criteria AND no ambiguous keywords | Ready to implement |
-| Manual skip | `--skip-brainstorm` flag passed | Human override |
-
-#### Gate Logic
-
-```python
-# Pseudocode
-def needs_brainstorm(task, skip_flag=False):
-    # Skip conditions (check first)
-    if skip_flag:
-        return False
-    if task.task_type in ["bug", "chore"]:
-        return False
-    if (len(task.description) >= 100 and
-        task.acceptance_criteria and
-        not has_ambiguous_keywords(task)):
-        return False
-
-    # Trigger conditions
-    if len(task.description) < 100:
-        return True, "Short description"
-    if not task.acceptance_criteria:
-        return True, "No acceptance criteria"
-    if task.task_type == "spike":
-        return True, "Spike investigation"
-    if has_ambiguous_keywords(task):
-        return True, "Ambiguous scope"
-
-    return False
-```
-
-#### Dispatching Brainstormer
-
-If brainstorm triggers:
-
-1. Dispatch brainstormer:
-   ```
-   Task tool:
-     subagent_type: "pokayokay:yokay-brainstormer"
-     description: "Brainstorm: {task.title}"
-     prompt: [Fill template from agents/templates/brainstorm-prompt.md]
-   ```
-
-   Template variables: `{TASK_ID}`, `{TASK_TITLE}`, `{TASK_TYPE}` (the ohno task's `task_type`), `{TASK_DESCRIPTION}`, `{ACCEPTANCE_CRITERIA}`, `{TRIGGER_REASON}` (which trigger condition fired the gate, e.g. "Short description" or "No acceptance criteria"), `{WORKING_DIRECTORY}`.
-
-2. Process brainstorm result:
-   - Update ohno task with refined requirements:
-     ```
-     update_task(task_id, {
-       description: refined_description,
-       acceptance_criteria: proposed_criteria
-     })
-     ```
-   - If open questions:
-     - **auto or unattended mode**: Auto-resolve — log open questions as assumptions, proceed with brainstormer's best judgment.
-       ```
-       add_task_activity(task_id, "decision", "Auto-resolved open questions as assumptions (auto/unattended mode): {questions}")
-       ```
-     - **supervised / semi-auto**: PAUSE for human input
-   - If refined: Proceed to Step 3.5 (validation), then the Design Review Gate (Step 3.7)
-
-3. Log activity:
-   ```
-   add_task_activity(task_id, "note", "Brainstorm: Refined requirements")
-   ```
-
-#### Brainstorm Flow
-
-```
-┌──────────────┐
-│  Get Task    │
-└──────┬───────┘
-       │
-       ▼
-┌──────────────┐     NO      ┌──────────────┐
-│ Needs        │────────────►│ Skip to      │
-│ Brainstorm?  │             │ Design Review│
-└──────┬───────┘             └──────────────┘
-       │ YES
-       ▼
-┌──────────────┐
-│ Brainstormer │
-│  Subagent    │
-└──────┬───────┘
-       │
-       ▼
-┌──────────────┐     QUESTIONS   ┌──────────────┐
-│ Result?      │────────────────►│ PAUSE for    │
-└──────┬───────┘                 │ human input* │
-       │ REFINED                 └──────────────┘
-       │        * supervised/semi-auto only; auto/unattended
-       │          auto-resolve questions as assumptions
-       ▼
-┌──────────────┐
-│ Update ohno  │
-│ with criteria│
-└──────┬───────┘
-       │
-       ▼
-┌──────────────┐
-│ Design Review│
-│  Gate (3.7)  │
-└──────┬───────┘
-       │
-       ▼
-┌──────────────┐
-│ Implementer  │
-└──────────────┘
-```
+Apply the trigger/skip conditions, AC quality check, brainstormer dispatch, and
+result processing in
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/dispatch-preparation.md`
+(Step 2: Brainstorm Gate). On **Refined**, update the ohno task and proceed to
+Step 3.5 (validation), then the Design Review Gate (Step 3.7); on
+**Needs Input**, PAUSE in supervised/semi-auto or auto-resolve the questions as
+logged assumptions in auto/unattended.
 
 ### 3.5 Pre-Implementation Validation
 
@@ -1154,7 +913,13 @@ If the gate is not skipped:
    task = get_task(task_id)
    ```
 
-2. Prepare context for subagent:
+2. Record the review baseline BEFORE dispatching:
+   ```bash
+   BASE_COMMIT=$(git rev-parse HEAD)
+   ```
+   Run this in the task's working directory (worktree or project root). Carry the value forward — chain-state or in-context — to the Step 5 review dispatches, where it fills `{BASE_COMMIT}` in both review templates. The implementer also records its own base commit (step 0 of its prompt); if the two differ, trust yours and note the discrepancy.
+
+3. Prepare context for subagent:
    - Task description (full text)
    - Acceptance criteria (from task or brainstorm output)
    - Architectural context (where this fits in the project)
@@ -1162,7 +927,7 @@ If the gate is not skipped:
    - Pre-validated approach (from Step 3.7 — fills `{APPROACH}`; use `Design review skipped — follow codebase patterns` if the gate was skipped)
    - Known pitfalls (from `memory/recurring-failures.md` if file exists — include entries matching the task domain as a "## Known Pitfalls" section in the implementer prompt)
 
-3. Dispatch subagent using Task tool:
+4. Dispatch subagent using Task tool:
    ```
    Task tool:
      subagent_type: "pokayokay:yokay-implementer"
@@ -1171,10 +936,11 @@ If the gate is not skipped:
      prompt: [Fill template from agents/templates/implementer-prompt.md]
    ```
 
-4. Process subagent result:
+5. Process subagent result:
    - If complete: Proceed to Step 4.5 (Auto-Fix Test Failures)
    - If NEEDS_REDESIGN: The pre-validated approach proved infeasible — see "Handling NEEDS_REDESIGN" below
    - If BLOCKED: Set blocker via ohno MCP (the report includes the implementer's specific open questions)
+   - If the dispatch itself failed or the report is suspect (tool error/timeout, empty or verdict-less report, questions-only, success claimed without a commit): apply the Dispatch Failure Protocol in `${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/dispatch-errors.md`
 
 #### Handling NEEDS_REDESIGN
 
@@ -1447,11 +1213,12 @@ variable can never reach the hook process.
      prompt: [Fill template from agents/templates/spec-review-prompt.md]
    ```
 
-   Fill `{IMPLEMENTATION_SUMMARY}` from the implementer's ohno handoff (`get_task_handoff(task_id)`), NOT from its inline report — the inline report is minimal; the AC verification table lives in the handoff details. Fill `{COMMIT_HASH}` with the bare hash from the implementer's commit (the template's `git diff` commands depend on it).
+   Fill `{IMPLEMENTATION_SUMMARY}` from the implementer's ohno handoff (`get_task_handoff(task_id)`), NOT from its inline report — the inline report is minimal; the AC verification table lives in the handoff details. Fill `{BASE_COMMIT}` with the baseline recorded in Step 4 before the implementer was dispatched (the template's primary `git diff {BASE_COMMIT}` command depends on it), and `{COMMIT_INFO}` with the implementer's commit (hash + message).
 
-2. Process result:
-   - **PASS**: Proceed to Stage 2 (quality review)
-   - **FAIL**: Re-dispatch implementer with spec issues (skip quality review)
+2. Process result — branch on the reviewer's final `VERDICT:` line (`VERDICT: PASS | FAIL | BLOCKED`), not on prose or evidence rows:
+   - **VERDICT: PASS**: Proceed to Stage 2 (quality review)
+   - **VERDICT: FAIL**: Re-dispatch implementer with spec issues (skip quality review)
+   - **VERDICT: BLOCKED**: The reviewer could not review (missing input — see the agent's enumerated cannot-review conditions). BLOCKED does NOT consume a review cycle and does NOT re-dispatch the implementer. Fix the input the reviewer named (e.g. fill the missing `{ACCEPTANCE_CRITERIA}`, correct `{BASE_COMMIT}` or the commit reference) and re-dispatch the reviewer ONCE. If still BLOCKED, mark the task blocked: `set_blocker(task_id, "Review blocked: {reviewer's stated reason}")`
 
 **What the spec reviewer checks:**
 - All acceptance criteria met against actual code (not implementer's claims)
@@ -1471,11 +1238,12 @@ Only runs if spec review passes.
      prompt: [Fill template from agents/templates/quality-review-prompt.md]
    ```
 
-   Fill `{APPROACH}` with the design-review approach stored in Step 3.7, or `None — design review was skipped` when the gate was skipped. Also fill `{COMMIT_HASH}` (bare hash) for the template's `git diff` commands.
+   Fill `{APPROACH}` with the design-review approach stored in Step 3.7, or `None — design review was skipped` when the gate was skipped. Fill `{ACCEPTANCE_CRITERIA}` from the task (input for the reviewer's Test-AC Mapping check). Also fill `{BASE_COMMIT}` with the Step 4 baseline for the template's `git diff` commands.
 
-2. Process result:
-   - **PASS**: Proceed to task completion (Step 6)
-   - **FAIL**: Re-dispatch implementer with quality issues
+2. Process result — branch on the reviewer's final `VERDICT:` line (`VERDICT: PASS | FAIL | BLOCKED`), not on prose or evidence rows:
+   - **VERDICT: PASS**: Proceed to task completion (Step 6)
+   - **VERDICT: FAIL**: Re-dispatch implementer with quality issues
+   - **VERDICT: BLOCKED**: Same handling as Stage 1 — no review cycle consumed, no implementer re-dispatch. Fix the reviewer's stated missing input and re-dispatch the reviewer ONCE; if still BLOCKED, `set_blocker(task_id, "Review blocked: {reviewer's stated reason}")`
 
 **What the quality reviewer checks:**
 - Code structure, readability, appropriate abstractions
@@ -1487,151 +1255,14 @@ Only runs if spec review passes.
 
 When either spec or quality review fails, `bridge.py` detects the FAIL in the
 reviewer's Task output (PostToolUse) and invokes the post-review-fail hook
-**automatically**. Do NOT run `hooks/post-review-fail.sh` yourself — manual
-invocation risks double execution (duplicate kaizen fix-task suggestions),
-and in consuming projects the script may not exist at all.
+**automatically** — do NOT run `hooks/post-review-fail.sh` yourself. The hook
+result surfaces as hook output context with a `kaizen_action` of AUTO
+(fix task auto-created — create it in ohno and block the current task),
+SUGGEST (prompt in supervised/semi-auto, auto-resolve in auto/unattended), or
+LOGGED (log and continue re-dispatch behavior).
 
-The bridge resolves the hook from the *project's* `hooks/post-review-fail.sh`
-(so projects can supply their own kaizen wiring). When the script is absent,
-the failure is still tracked locally (recurring-failure detection +
-graduate-rules) and the outcome is `kaizen_action: LOGGED`.
-
-The hook result surfaces as hook output context after the reviewer's Task
-call, with a `kaizen_action` of AUTO, SUGGEST, or LOGGED (plus `fix_task`
-details when available). The coordinator's only job is to act on that
-outcome:
-
-**1. AUTO Action (High Confidence)**
-
-Hook detects a well-known failure pattern and auto-creates a fix task.
-
-```json
-{
-  "action": "AUTO",
-  "fix_task": {
-    "title": "Fix: Missing error handling in API endpoint",
-    "description": "Review failed due to missing error handling...",
-    "type": "bug",
-    "estimate": 2
-  }
-}
-```
-
-Coordinator behavior:
-1. Create fix task in ohno:
-   ```bash
-   npx @stevestomp/ohno-cli create "${fix_task.title}" \
-     -t ${fix_task.type} \
-     --description "${fix_task.description}" \
-     -e ${fix_task.estimate} \
-     --source "kaizen-fix"
-   ```
-2. Block current task on the fix task:
-   ```bash
-   npx @stevestomp/ohno-cli dep add <current-task-id> <fix-task-id>
-   npx @stevestomp/ohno-cli block <current-task-id> "Blocked by fix task ${fix_task_id}"
-   ```
-3. Log activity:
-   ```bash
-   add_task_activity(task_id, "note", "Review failed, fix task auto-created: ${fix_task_id}")
-   ```
-4. Get next task and continue work loop
-
-**2. SUGGEST Action (Medium Confidence)**
-
-Hook has a suggestion but needs user confirmation.
-
-```json
-{
-  "action": "SUGGEST",
-  "fix_task": {
-    "title": "Fix: Improve test coverage for edge cases",
-    "description": "Review suggests adding tests for...",
-    "type": "test",
-    "estimate": 3
-  },
-  "confidence": "medium"
-}
-```
-
-Coordinator behavior:
-1. Present suggestion to user:
-   ```markdown
-   Review failed. Suggested fix task:
-   - Title: ${fix_task.title}
-   - Type: ${fix_task.type}
-   - Estimate: ${fix_task.estimate}h
-   - Description: ${fix_task.description}
-
-   Create fix task? (yes/no/customize)
-   ```
-2. Handle user response:
-   - **yes**: Create fix task, block current task, get next task
-   - **no**: Continue with existing re-dispatch behavior (max 3 cycles)
-   - **customize**: Let user modify fix_task details, then create
-
-**3. LOGGED Action (Low Confidence)**
-
-Hook cannot confidently suggest a fix task, only logs the failure.
-
-```json
-{
-  "action": "LOGGED",
-  "message": "Failure logged to kaizen database"
-}
-```
-
-Coordinator behavior:
-1. Log activity:
-   ```bash
-   add_task_activity(task_id, "note", "Review failed: ${FAILURE_DETAILS}")
-   ```
-2. Continue with existing re-dispatch behavior (max 3 cycles)
-
-**Hook Integration Flow:**
-
-```
-Review FAIL
-     │
-     ▼
-┌─────────────────┐
-│ bridge.py runs  │
-│ post-review-fail│
-│ (automatic)     │
-└────────┬────────┘
-         │
-         ▼
- Read kaizen_action
- from hook output
-         │
-    ┌────┴─────┬─────────────┐
-    │          │             │
-    ▼          ▼             ▼
-┌──────┐  ┌─────────┐  ┌──────────┐
-│ AUTO │  │ SUGGEST │  │ LOGGED   │
-└───┬──┘  └────┬────┘  └─────┬────┘
-    │          │              │
-    ▼          ▼              │
-┌──────────┐  ┌──────────┐   │
-│ Create   │  │ Prompt   │   │
-│ fix task │  │ user     │   │
-└─────┬────┘  └────┬─────┘   │
-      │            │         │
-      │       ┌────┴─────┐   │
-      │       │          │   │
-      │      yes        no   │
-      │       │          │   │
-      ▼       ▼          ▼   ▼
-┌─────────────────────────────┐
-│ Block current task          │
-│ Get next task               │
-└─────────────────────────────┘
-                  OR
-┌─────────────────────────────┐
-│ Re-dispatch implementer     │
-│ (existing behavior)         │
-└─────────────────────────────┘
-```
+Follow the per-action coordinator behavior in
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/kaizen-review-failures.md`.
 
 #### Review Loop
 
@@ -1728,7 +1359,10 @@ Review FAIL
 **Re-dispatch rules:**
 - Include specific issues from review
 - Reference original acceptance criteria
-- Maximum 3 review cycles (then escalate to human)
+- Maximum 3 review cycles (BLOCKED verdicts don't count), then escalate per mode:
+  - **supervised / semi-auto**: PAUSE — present the review history and options to the human. Also pause when a reviewer returns BLOCKED twice for the same task.
+  - **auto / unattended**: Do NOT pause. Call `mcp__ohno__set_needs_rework(task_id, reason)` (or `set_blocker` when rework does not apply), log via `add_task_activity`, and continue to the next task.
+- **Hard rule**: A task whose review did not end in PASS is NEVER marked done.
 
 #### Logging Reviews to ohno
 
@@ -1962,115 +1596,23 @@ Use ohno MCP to log:
 
 ### 3. Session Chaining (if headless)
 
-When session ends with remaining work in scope:
-
-1. SessionEnd hook calls `session-chain.sh`
-2. Script checks remaining ready tasks via ohno
-3. If tasks remain and chain limit not reached:
-   - Spawns/prepares the next session using the active runtime, for example `claude -p "/work --continue <scope-flag>"` or `codex --prompt="/work --continue <scope-flag>"`
-4. If chain complete or limit reached:
-   - Generates report to `.ohno/reports/chain-{id}-report.md`
-   - Notifies via configured method
-   - Deletes chain state file
-
-#### Chain State File
-
-Chain state is communicated between the coordinator and hooks via `.pokayokay/pokayokay-chain-state.json`, with `.claude/pokayokay-chain-state.json` retained as a legacy fallback.
-
-**The coordinator MUST write this file at session start** when running auto mode with scope.
-Use the Write tool to create it:
-
-```json
-{
-  "chain_id": "chain-<unix-timestamp>",
-  "chain_index": 0,
-  "scope_type": "all",
-  "scope_id": "",
-  "tasks_completed": 0,
-  "adaptive_n": 2,
-  "batches_completed": 0,
-  "batches_failed": 0,
-  "failed_tasks": [],
-  "conflict_tasks": [],
-  "last_session_summary": ""
-}
-```
-
-- `chain_id`: Generate as `chain-<unix-timestamp>` (e.g., `chain-1738764000`)
-- `chain_index`: Start at 0, auto-incremented by bridge.py on each chain
-- `scope_type`: "epic", "story", or "all" (from `--epic`, `--story`, or `--all` flag)
-- `scope_id`: The epic/story ID (empty string for "all")
-- `tasks_completed`: Starts at 0, auto-incremented by bridge.py on each task completion
-- `adaptive_n`: Current parallel count (written by coordinator before shutdown)
-- `batches_completed`: Successful batch count (for adaptive sizing decisions)
-- `batches_failed`: Failed batch count (for adaptive sizing decisions)
-- `failed_tasks`: Task IDs that failed or got blocked (skip on resume)
-- `conflict_tasks`: Task IDs with git conflicts (flag for manual resolution)
-- `last_session_summary`: Brief summary of what the last session accomplished
-
-**When `--continue`**: Read the existing state file. Do NOT overwrite it — bridge.py
-already incremented `chain_index` and tracks `tasks_completed`. Restore coordinator state
-from extended fields (`adaptive_n`, `failed_tasks`, etc.).
-
-**When NOT auto or no scope**: Do NOT write the state file. Non-chaining sessions
-should not have a state file.
-
-Bridge.py handles:
-- Reading the state file on SessionEnd to pass to session-chain.sh
-- Incrementing `tasks_completed` on each task completion
-- Incrementing `chain_index` when spawning the next session
-- Deleting the state file when the chain completes or hits the limit
+When a session ends with remaining work in scope, the SessionEnd hook calls
+`session-chain.sh`, which spawns/prepares the next runtime session
+(`/work --continue <scope-flag>`) until the scope completes or the chain limit
+is reached. Chain state is communicated between the coordinator and hooks via
+`.pokayokay/pokayokay-chain-state.json` (legacy fallback:
+`.claude/pokayokay-chain-state.json`).
 
 ### 4. Chain Completion Audit
 
-When all tasks in scope are done, the chain runs a completeness audit before declaring success.
+When all tasks in scope are done, the chain runs a completeness audit
+(dispatching `pokayokay:yokay-auditor` against the concept doc / PRD) before
+declaring success; audit state is tracked via the `audit_pending` /
+`audit_passed` chain-state fields.
 
-#### How It Works
-
-1. `session-chain.sh` detects `READY_COUNT == 0` but `CHAIN_AUDITED != true`
-2. Returns `audit_pending` instead of `complete`
-3. `bridge.py` sets `chain_state.audit_pending = true` (does NOT delete chain state)
-4. On next session start (via chain continue), coordinator detects `audit_pending`:
-
-**Coordinator audit logic (run at session start when `--continue` and audit_pending):**
-
-```
-Read chain state → check audit_pending == true
-
-If audit_pending:
-  1. Find the concept doc / PRD:
-     - Check docs/plans/*.md, docs/concepts/*.md
-     - Check epic description if scope is epic
-     - Check PROJECT.md
-  2. Dispatch `pokayokay:yokay-auditor` (Task tool subagent_type):
-     - Pass: concept doc content + scope info
-     - Instruction: "Verify all requirements are implemented. Return PASS or FAIL with gap list."
-  3. Process result:
-     - PASS:
-       - Set chain_state.audit_passed = true
-       - Set chain_state.audit_pending = false
-       - Save chain state
-       - Session ends → session-chain.sh sees CHAIN_AUDITED=true → "complete"
-     - FAIL with gaps:
-       - Create remediation tasks in ohno for each gap
-       - Set chain_state.audit_pending = false (audit ran, even if failed)
-       - Continue working on remediation tasks
-       - When those complete, audit runs again (next chain end)
-```
-
-#### Chain State Fields
-
-The following fields are added to the chain state for audit tracking:
-
-```json
-{
-  "audit_pending": false,
-  "audit_passed": false
-}
-```
-
-- `audit_pending`: Set to `true` by bridge.py when all tasks done but audit not yet run
-- `audit_passed`: Set to `true` by coordinator when audit passes. Passed to session-chain.sh as `CHAIN_AUDITED`
+For the chain state file schema, field-by-field ownership (coordinator vs
+bridge.py), and the full audit logic, read
+`${CLAUDE_PLUGIN_ROOT}/skills/work-session/references/chain-state.md`.
 
 ## Modes Reference
 
@@ -2111,7 +1653,7 @@ At time-box end, MUST produce decision:
 - **MORE-INFO**: (Rare) Create follow-up spike, max 1 re-spike
 
 ### 4. Output Location
-Save spike report to `.claude/spikes/[name]-[date].md`
+Save spike report to `.claude/spikes/[date]-[slug].md`
 
 ## Bug Discovery During Work
 

--- a/plugins/pokayokay/hooks/actions/bridge.py
+++ b/plugins/pokayokay/hooks/actions/bridge.py
@@ -1638,15 +1638,64 @@ def handle_review_complete(tool_input: dict, tool_response: dict) -> dict:
     # normalized by normalize_hook_input. extract_output_text handles both.
     agent_output = extract_output_text(tool_response)
 
-    # Detect PASS/FAIL
-    if ": PASS" in agent_output:
+    # Detect the review verdict. Primary signal: the reviewer contract's
+    # terminal line — branch on the LAST `VERDICT: PASS|FAIL|BLOCKED` match
+    # so a report that quotes the contract earlier cannot be misread.
+    verdicts = re.findall(r'^VERDICT:\s*(PASS|FAIL|BLOCKED)\s*$', agent_output, re.MULTILINE)
+    if verdicts:
+        verdict = verdicts[-1]
+    else:
+        # Fallback: anchored report headings. FAIL takes precedence
+        # regardless of order — a FAIL heading anywhere means the review
+        # failed, even if evidence lines elsewhere mention "PASS".
+        headings = re.findall(
+            r'^##\s+(?:Spec|Quality)\s+Review:\s*(PASS|FAIL|BLOCKED)\b',
+            agent_output,
+            re.MULTILINE,
+        )
+        if "FAIL" in headings:
+            verdict = "FAIL"
+        elif "BLOCKED" in headings:
+            verdict = "BLOCKED"
+        elif "PASS" in headings:
+            verdict = "PASS"
+        else:
+            verdict = None
+
+    if verdict == "PASS":
         return {"skip": True, "reason": "review passed"}
 
-    if ": FAIL" not in agent_output:
-        return {"skip": True, "reason": "could not determine review result"}
+    if verdict == "BLOCKED":
+        # BLOCKED is a non-verdict for kaizen purposes: the reviewer could
+        # not review (missing input), the implementation did not fail. The
+        # coordinator handles BLOCKED itself (fix the reviewer's input and
+        # re-dispatch the reviewer once) — never route it into
+        # post-review-fail or failure tracking.
+        return {"skip": True, "reason": "review blocked (cannot-review), not a failure"}
 
     # Extract failure source
     failure_source = "spec-review" if is_spec_review else "quality-review"
+
+    if verdict is None:
+        # Unparseable reviewer output. Fail closed only when the dispatch is
+        # unambiguously a reviewer (subagent_type match); keep the silent
+        # skip for description-only matches so non-reviewer Tasks that
+        # merely mention "spec review" don't raise false alarms.
+        if "spec-review" not in subagent_type and "quality-review" not in subagent_type:
+            return {"skip": True, "reason": "could not determine review result"}
+        return {
+            "review_type": failure_source,
+            "task_id": get_active_task_id() or "unknown",
+            "verdict": "UNPARSEABLE",
+            "summary": (
+                "Review verdict could not be parsed: the reviewer output has no "
+                "terminal 'VERDICT: PASS|FAIL|BLOCKED' line and no "
+                "'## Spec/Quality Review:' heading. Treat this review as FAIL "
+                "and re-dispatch the reviewer."
+            ),
+        }
+
+    # verdict == "FAIL": proceed with the failure path below.
 
     # Get task ID from the task state file (written by handle_task_start;
     # env var is a legacy fallback for direct invocations)

--- a/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
+++ b/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
@@ -50,21 +50,34 @@ if [ -z "$FILES" ]; then
       FILES=$(git diff --name-only --diff-filter=ACM 2>/dev/null | grep "$REF_PATTERN" || true)
     elif echo "$GIT_COMMAND" | grep -qE "$ADD_CMD"; then
       # `git add <pathspec>...`: gate reference files the add will stage.
-      # Extract the pathspec region of each `git add` (everything up to the
-      # next shell separator), tokenize it, and match candidates with bash
-      # glob semantics: a token gates a candidate when it names it exactly,
-      # names a parent directory, or glob-matches it (references/*.md).
-      # Scoping tokens to the add region keeps commit-message words from
-      # false-blocking, and `demo-other` never matches a demo/ candidate.
-      # Quoted pathspecs containing spaces are split — a known limitation.
+      # bridge.py neutralizes shell separators (&& ; | ( )) to spaces before
+      # we see the command, so the pathspec region cannot be bounded by them.
+      # Instead collect the tokens after the first `add`, STOPPING at the next
+      # `commit` keyword (where the commit message begins) and skipping the
+      # bare `git` word of a following compound command. This keeps commit-
+      # message text from false-blocking an unrelated add. Candidates match by
+      # exact path, parent directory, or glob (references/*.md).
       SCOPE="about-to-be-staged"
       CANDIDATES=$(list_working_tree_refs)
       NL=$'\n'
       FILES=""
-      ADD_REGIONS=$(printf '%s' "$GIT_COMMAND" |
-        grep -oE 'git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*add[[:space:]][^;&|)]*' |
-        sed -E 's/^git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*add[[:space:]]//')
-      TOKENS=$(printf '%s\n' "$ADD_REGIONS" | tr ' \t' '\n\n')
+      # Extract pathspec tokens (tr avoids for-loop glob expansion).
+      ALL_TOKENS=$(printf '%s' "$GIT_COMMAND" | tr ' \t' '\n\n')
+      PATHSPECS=""
+      seen_add=""
+      while IFS= read -r tok; do
+        [ -n "$tok" ] || continue
+        if [ -z "$seen_add" ]; then
+          [ "$tok" = "add" ] && seen_add=1
+          continue
+        fi
+        # Boundary of the pathspec list: the commit command's message follows.
+        [ "$tok" = "commit" ] && break
+        # Skip the git command word of a chained command, and option flags.
+        [ "$tok" = "git" ] && continue
+        case "$tok" in -*) continue ;; esac
+        PATHSPECS="${PATHSPECS}${PATHSPECS:+$NL}${tok}"
+      done <<< "$ALL_TOKENS"
       while IFS= read -r candidate; do
         [ -n "$candidate" ] || continue
         matched=""
@@ -72,7 +85,6 @@ if [ -z "$FILES" ]; then
           [ -n "$token" ] || continue
           token="${token#\"}"; token="${token%\"}"
           token="${token#\'}"; token="${token%\'}"
-          case "$token" in ''|-*) continue ;; esac
           token="${token#./}"
           token="${token%/}"
           if [ "$token" = "." ] || [ -z "$token" ]; then
@@ -84,7 +96,7 @@ if [ -z "$FILES" ]; then
           case "$candidate" in
             $token|$token/*) matched=1; break ;;
           esac
-        done <<< "$TOKENS"
+        done <<< "$PATHSPECS"
         [ -n "$matched" ] && FILES="${FILES}${FILES:+$NL}${candidate}"
       done <<< "$CANDIDATES"
     fi

--- a/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
+++ b/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
@@ -52,11 +52,13 @@ if [ -z "$FILES" ]; then
       # `git add <pathspec>...`: gate reference files the add will stage.
       # bridge.py neutralizes shell separators (&& ; | ( )) to spaces before
       # we see the command, so the pathspec region cannot be bounded by them.
-      # Instead collect the tokens after the first `add`, STOPPING at the next
-      # `commit` keyword (where the commit message begins) and skipping the
-      # bare `git` word of a following compound command. This keeps commit-
-      # message text from false-blocking an unrelated add. Candidates match by
-      # exact path, parent directory, or glob (references/*.md).
+      # Instead toggle collection at each `add`/`commit` boundary: tokens
+      # inside a `git add ...` segment are pathspecs; a `commit` ends the
+      # segment (its message must never be collected). This scans EVERY add
+      # segment in a compound command, not just the first, so a later
+      # `&& git add <oversized-ref>` cannot slip past the gate. The bare `git`
+      # word of a chained command and option flags are skipped. Candidates
+      # match by exact path, parent directory, or glob (references/*.md).
       SCOPE="about-to-be-staged"
       CANDIDATES=$(list_working_tree_refs)
       NL=$'\n'
@@ -64,16 +66,14 @@ if [ -z "$FILES" ]; then
       # Extract pathspec tokens (tr avoids for-loop glob expansion).
       ALL_TOKENS=$(printf '%s' "$GIT_COMMAND" | tr ' \t' '\n\n')
       PATHSPECS=""
-      seen_add=""
+      collecting=""
       while IFS= read -r tok; do
         [ -n "$tok" ] || continue
-        if [ -z "$seen_add" ]; then
-          [ "$tok" = "add" ] && seen_add=1
-          continue
-        fi
-        # Boundary of the pathspec list: the commit command's message follows.
-        [ "$tok" = "commit" ] && break
-        # Skip the git command word of a chained command, and option flags.
+        if [ "$tok" = "add" ]; then collecting=1; continue; fi
+        if [ "$tok" = "commit" ]; then collecting=""; continue; fi
+        [ -n "$collecting" ] || continue
+        # Inside an add segment: skip the git word of a chained command and
+        # option flags; everything else is a pathspec.
         [ "$tok" = "git" ] && continue
         case "$tok" in -*) continue ;; esac
         PATHSPECS="${PATHSPECS}${PATHSPECS:+$NL}${tok}"

--- a/plugins/pokayokay/skills/feature-audit/references/anti-patterns.md
+++ b/plugins/pokayokay/skills/feature-audit/references/anti-patterns.md
@@ -4,7 +4,7 @@
 
 | Anti-Pattern | Problem | Fix |
 |--------------|---------|-----|
-| Trusting tasks.db status | "Done" ≠ user-facing | Always verify in codebase |
+| Trusting task status (ohno) | "Done" ≠ user-facing | Always verify in codebase |
 | Only checking file existence | File may be empty/stub | Check for real implementation |
 | Ignoring navigation | Feature unreachable | Verify menu/nav links |
 | Skipping mobile | Desktop-only isn't complete | Check responsive/native |

--- a/plugins/pokayokay/skills/feature-audit/references/remediation-templates.md
+++ b/plugins/pokayokay/skills/feature-audit/references/remediation-templates.md
@@ -4,7 +4,32 @@ Pre-built task templates for common gaps identified during feature audits.
 
 ## Template Usage
 
-When a gap is identified, use these templates to generate properly-structured remediation tasks that integrate with tasks.db.
+When a gap is identified, use these templates to generate properly-structured remediation tasks, created in ohno via `mcp__ohno__create_task` (CLI equivalent: `npx @stevestomp/ohno-cli create "<title>" -t <type>`). Never write ohno's internal database directly.
+
+One call per gap, using the matching markdown template below as the description source:
+
+```
+mcp__ohno__create_task({
+  story_id: "[story-id]",
+  title: "[Remediation] [F0XX]: Create /[route] page",
+  description: "Create the main page for [Feature Name] with data fetching, loading, and error states.",
+  task_type: "feature",
+  estimate_hours: 6
+})
+```
+
+| Gap | Task Title | task_type | estimate_hours | Story |
+|-----|------------|-----------|----------------|-------|
+| No frontend route | Create /[route] page | feature | 6 | [Feature] frontend |
+| No navigation link | Add [Feature] to navigation | feature | 1 | [Feature] frontend |
+| No API integration | Connect [Feature] UI to backend API | feature | 5 | [Feature] frontend |
+| No loading state | Add loading skeleton to [Feature] | feature | 2 | [Feature] polish |
+| No error state | Add error handling to [Feature] | feature | 3 | [Feature] polish |
+| No empty state | Add empty state to [Feature] | feature | 2 | [Feature] polish |
+| No documentation | Write help documentation for [Feature] | chore | 3 | [Feature] docs |
+| No mobile support | Make [Feature] mobile-responsive | feature | 6 | [Feature] polish |
+
+Prefix titles with `[Remediation] [FEATURE-ID]:` for traceability (see Task Naming Convention below).
 
 ---
 
@@ -84,21 +109,6 @@ Create screen for [Feature] and add to navigation.
 - `src/navigation/MainNavigator.tsx` (add screen)
 ```
 
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-route',
-    'story-[FEATURE]-frontend',
-    'Create /[route] page',
-    'Create the main page for [Feature Name] with data fetching, loading, and error states.',
-    'frontend',
-    6,
-    'todo'
-);
-```
-
 ---
 
 ## Gap: No Navigation Link
@@ -136,21 +146,6 @@ Add navigation link to [Feature] in the main navigation/sidebar.
 - Icon suggestion: [appropriate icon name]
 - Position: After [existing item]
 - Group: [navigation group if applicable]
-```
-
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-nav',
-    'story-[FEATURE]-frontend',
-    'Add [Feature] to navigation',
-    'Add navigation link to [Feature Name] in the main sidebar/navigation.',
-    'frontend',
-    1,
-    'todo'
-);
 ```
 
 ---
@@ -193,21 +188,6 @@ Wire up the [Feature] frontend components to call the backend API.
 - DELETE /api/[feature]/:id → useDelete[Feature]Mutation
 ```
 
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-api-integration',
-    'story-[FEATURE]-frontend',
-    'Connect [Feature] UI to backend API',
-    'Create API client and React Query hooks, wire up components to use real data.',
-    'frontend',
-    5,
-    'todo'
-);
-```
-
 ---
 
 ## Gap: No Loading State
@@ -244,21 +224,6 @@ Add skeleton/loading UI to [Feature] for better UX during data fetching.
 - `src/components/[Feature]/[Feature]Skeleton.tsx` (new)
 - `src/components/[Feature]/[Feature].tsx` (add loading check)
 - OR `app/[route]/loading.tsx` (Next.js)
-```
-
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-loading',
-    'story-[FEATURE]-polish',
-    'Add loading skeleton to [Feature]',
-    'Create skeleton component that matches content layout, show during data fetching.',
-    'frontend',
-    2,
-    'todo'
-);
 ```
 
 ---
@@ -302,21 +267,6 @@ Add proper error UI and recovery options to [Feature].
 - OR `app/[route]/error.tsx` (Next.js)
 ```
 
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-error',
-    'story-[FEATURE]-polish',
-    'Add error handling to [Feature]',
-    'Create error UI with retry option, handle different error types appropriately.',
-    'frontend',
-    3,
-    'todo'
-);
-```
-
 ---
 
 ## Gap: No Empty State
@@ -352,21 +302,6 @@ Add helpful empty state when [Feature] has no data.
 **Files to Create/Modify**:
 - `src/components/[Feature]/[Feature]Empty.tsx` (new)
 - `src/components/[Feature]/[Feature]List.tsx` (add empty check)
-```
-
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-empty',
-    'story-[FEATURE]-polish',
-    'Add empty state to [Feature]',
-    'Create helpful empty state with explanation and CTA when no data exists.',
-    'frontend',
-    2,
-    'todo'
-);
 ```
 
 ---
@@ -407,21 +342,6 @@ Create help documentation for [Feature].
 **Files to Create**:
 - `docs/features/[feature].md`
 - Update `docs/index.md` with link
-```
-
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-docs',
-    'story-[FEATURE]-docs',
-    'Write help documentation for [Feature]',
-    'Create help article with purpose, instructions, screenshots, and FAQ.',
-    'documentation',
-    3,
-    'todo'
-);
 ```
 
 ---
@@ -468,21 +388,6 @@ Ensure [Feature] works well on mobile devices.
 - Related CSS/Tailwind classes
 ```
 
-### SQL Insert
-
-```sql
-INSERT INTO tasks (id, story_id, title, description, task_type, estimate_hours, status)
-VALUES (
-    'task-[FEATURE]-mobile',
-    'story-[FEATURE]-polish',
-    'Make [Feature] mobile-responsive',
-    'Ensure layout works on mobile, touch targets adequate, all functionality accessible.',
-    'frontend',
-    6,
-    'todo'
-);
-```
-
 ---
 
 ## Gap: Full Frontend Missing
@@ -513,145 +418,72 @@ Build the complete frontend for [Feature], including all screens, components, an
 
 ---
 
-### Tasks:
+### Tasks (all Type: Frontend):
 
-#### 1. Create [Feature] page structure
-- **Type**: Frontend
-- **Hours**: 2
-- Create page file with layout
-
-#### 2. Build [Feature] list component
-- **Type**: Frontend  
-- **Hours**: 4
-- List/table of items with pagination
-
-#### 3. Build [Feature] detail component
-- **Type**: Frontend
-- **Hours**: 4
-- Detail view / edit form
-
-#### 4. Build [Feature] create/edit form
-- **Type**: Frontend
-- **Hours**: 4
-- Form with validation
-
-#### 5. Create API integration hooks
-- **Type**: Frontend
-- **Hours**: 4
-- React Query hooks for all endpoints
-
-#### 6. Add loading/error/empty states
-- **Type**: Frontend
-- **Hours**: 3
-- Polish states
-
-#### 7. Add to navigation
-- **Type**: Frontend
-- **Hours**: 1
-- Sidebar link
-
-#### 8. Mobile responsive pass
-- **Type**: Frontend
-- **Hours**: 4
-- Responsive adjustments
+| # | Task | Hours | Notes |
+|---|------|-------|-------|
+| 1 | Create [Feature] page structure | 2 | Page file with layout |
+| 2 | Build [Feature] list component | 4 | List/table of items with pagination |
+| 3 | Build [Feature] detail component | 4 | Detail view / edit form |
+| 4 | Build [Feature] create/edit form | 4 | Form with validation |
+| 5 | Create API integration hooks | 4 | React Query hooks for all endpoints |
+| 6 | Add loading/error/empty states | 3 | Polish states |
+| 7 | Add [Feature] to navigation | 1 | Sidebar link |
+| 8 | Mobile responsive pass | 4 | Responsive adjustments |
 ```
 
-### SQL Insert (Story + Tasks)
+### ohno Creation (Story + Tasks)
 
-```sql
--- Create story
-INSERT INTO stories (id, epic_id, title, description, estimate_days, status)
-VALUES (
-    'story-[FEATURE]-frontend',
-    'epic-[FEATURE]',
-    '[Feature] Frontend Implementation',
-    'Build complete frontend including pages, components, API integration, and polish.',
-    4,
-    'todo'
-);
+Create the story first, then one `mcp__ohno__create_task` per task above (with the returned story ID, `task_type: "feature"`, hours as listed):
 
--- Create tasks
-INSERT INTO tasks (id, story_id, title, task_type, estimate_hours, status) VALUES
-    ('task-[F]-f01', 'story-[FEATURE]-frontend', 'Create [Feature] page structure', 'frontend', 2, 'todo'),
-    ('task-[F]-f02', 'story-[FEATURE]-frontend', 'Build [Feature] list component', 'frontend', 4, 'todo'),
-    ('task-[F]-f03', 'story-[FEATURE]-frontend', 'Build [Feature] detail component', 'frontend', 4, 'todo'),
-    ('task-[F]-f04', 'story-[FEATURE]-frontend', 'Build [Feature] create/edit form', 'frontend', 4, 'todo'),
-    ('task-[F]-f05', 'story-[FEATURE]-frontend', 'Create API integration hooks', 'frontend', 4, 'todo'),
-    ('task-[F]-f06', 'story-[FEATURE]-frontend', 'Add loading/error/empty states', 'frontend', 3, 'todo'),
-    ('task-[F]-f07', 'story-[FEATURE]-frontend', 'Add [Feature] to navigation', 'frontend', 1, 'todo'),
-    ('task-[F]-f08', 'story-[FEATURE]-frontend', 'Mobile responsive pass', 'frontend', 4, 'todo');
-
--- Add dependencies
-INSERT INTO dependencies (blocker_task_id, blocked_task_id) VALUES
-    ('task-[F]-f01', 'task-[F]-f02'),
-    ('task-[F]-f01', 'task-[F]-f03'),
-    ('task-[F]-f02', 'task-[F]-f05'),
-    ('task-[F]-f05', 'task-[F]-f06'),
-    ('task-[F]-f06', 'task-[F]-f07'),
-    ('task-[F]-f07', 'task-[F]-f08');
 ```
+mcp__ohno__create_story({
+  epic_id: "[epic-id]",
+  title: "[Feature] Frontend Implementation",
+  description: "Build complete frontend including pages, components, API integration, and polish."
+})
+```
+
+Then chain dependencies with the returned task IDs via `mcp__ohno__add_dependency` (task_id depends on depends_on_task_id): page structure blocks list and detail components; list blocks API hooks; hooks block states; states block navigation; navigation blocks the responsive pass.
 
 ---
 
 ## Batch Remediation
 
+Batch scripts key off the `Audit (...)` lines recorded in epic descriptions (see [gap-analysis.md](gap-analysis.md), "Gap Tracking in ohno").
+
 ### All Missing Navigation
 
-```sql
--- Find all features missing navigation
-SELECT e.id, e.title 
-FROM epics e 
-WHERE e.audit_level = 3;  -- Routable but not in nav
-
--- Generate tasks for all
-INSERT INTO tasks (id, story_id, title, task_type, estimate_hours, status)
-SELECT 
-    'task-' || e.id || '-nav',
-    'story-' || e.id || '-frontend', 
-    'Add ' || e.title || ' to navigation',
-    'frontend',
-    1,
-    'todo'
-FROM epics e
-WHERE e.audit_level = 3;
+```bash
+# Find all features audited at L3 (routable but not in nav), create nav tasks
+npx @stevestomp/ohno-cli epics --json | node -e '
+const epics = JSON.parse(require("fs").readFileSync(0, "utf8"));
+for (const e of epics) {
+  if (/Audit \([^)]*\): L3/.test(e.description || "")) {
+    console.log(`${e.id}\t${e.title}`);
+  }
+}' | while IFS=$'\t' read -r id title; do
+    npx @stevestomp/ohno-cli create "[Remediation] $id: Add $title to navigation" -t feature
+done
 ```
 
 ### All Missing Documentation
 
-```sql
--- Find all features missing docs
-SELECT e.id, e.title 
-FROM epics e 
-WHERE e.audit_gaps LIKE '%no_docs%';
-
--- Generate doc tasks for all
-INSERT INTO tasks (id, story_id, title, task_type, estimate_hours, status)
-SELECT 
-    'task-' || e.id || '-docs',
-    'story-' || e.id || '-docs', 
-    'Write documentation for ' || e.title,
-    'documentation',
-    3,
-    'todo'
-FROM epics e
-WHERE e.audit_gaps LIKE '%no_docs%';
-```
+Same pattern: filter for descriptions matching `/Audit \([^)]*\):.*no_docs/` and create `[Remediation] $id: Write documentation for $title` tasks with `-t chore`.
 
 ---
 
-## Task ID Convention
+## Task Naming Convention
+
+ohno assigns task and story IDs — don't invent your own. Encode traceability in titles instead:
 
 ```
-task-[EPIC]-[TYPE][NUMBER]
+[Remediation] [FEATURE-ID]: [action]
 
 Examples:
-- task-028-f01  → Epic 028, Frontend task 1
-- task-028-b01  → Epic 028, Backend task 1
-- task-028-d01  → Epic 028, Documentation task 1
-- task-028-p01  → Epic 028, Polish task 1
-
-Story IDs:
-- story-028-frontend  → Frontend work for epic 028
-- story-028-polish    → Polish work for epic 028
-- story-028-docs      → Documentation for epic 028
+- [Remediation] F028: Create /reports page
+- [Remediation] F028: Add Reports to navigation
+- [Remediation] F028: Write documentation for Reports
 ```
+
+Group related remediation tasks under a story per feature (e.g. "F028 Frontend Remediation") so `mcp__ohno__get_tasks` output stays scannable.

--- a/plugins/pokayokay/skills/planning/references/anti-patterns.md
+++ b/plugins/pokayokay/skills/planning/references/anti-patterns.md
@@ -25,7 +25,7 @@
 
 | Anti-Pattern | Problem | Fix |
 |--------------|---------|-----|
-| Output to random location | Skills can't find | Always use `.claude/` |
+| Output to random location | Skills can't find | Artifacts in `.claude/`, plan state in ohno |
 | No PROJECT.md | No shared context | Always generate PROJECT.md |
 | No skill assignments | Manual routing needed | Assign skills during analysis |
-| Missing features.json | No machine-readable list | Always generate features.json |
+| Plan not persisted | Skills can't find work | Create epic/story/task hierarchy in ohno |

--- a/plugins/pokayokay/skills/planning/references/design-integration.md
+++ b/plugins/pokayokay/skills/planning/references/design-integration.md
@@ -199,7 +199,7 @@ Update the skill hints table (Section 4) to explicitly include design routing:
 - User flows, wireframes, IA → `ux-design` (task_type: `ux`)
 - Visual components, styling → `aesthetic-ui-designer` (task_type: `ui`)
 - User research, personas → `persona-creation` (task_type: `persona`)
-- Accessibility requirements → `accessibility-auditor` (task_type: `a11y`)
+- Accessibility requirements → `design:a11y` (task_type: `a11y`)
 
 When design plugin is available, these skills map to `/design:*` commands.
 When not available, tasks use standard skill-based implementation.
@@ -213,7 +213,7 @@ Add design keywords to the main keyword detection table:
 | wireframe, mockup, user flow, journey, ia | ux-design | ux |
 | visual, component, design system, tokens | aesthetic-ui-designer | ui |
 | persona, user research, empathy map | persona-creation | persona |
-| accessibility, a11y, wcag, screen reader | accessibility-auditor | a11y |
+| accessibility, a11y, wcag, screen reader | design:a11y | a11y |
 
 ## Integration with Work Command
 

--- a/plugins/pokayokay/skills/planning/references/project-md-template.md
+++ b/plugins/pokayokay/skills/planning/references/project-md-template.md
@@ -50,8 +50,7 @@ The most important output — shared context for all skills.
 
 ## Key Files
 - PRD: [path or "uploaded"]
-- Tasks DB: `.claude/tasks.db`
-- Kanban: `.claude/kanban.html`
+- Plan state: ohno (`.ohno/`, via MCP tools / `npx @stevestomp/ohno-cli`)
 
 ## Session Log
 | Date | Session | Completed | Notes |

--- a/plugins/pokayokay/skills/planning/references/skill-routing.md
+++ b/plugins/pokayokay/skills/planning/references/skill-routing.md
@@ -146,54 +146,33 @@ Skills should run in this order:
 
 ## Skill State Tracking
 
-### In tasks.db
+### In ohno
 
-```sql
--- Track skill assignment at epic level
-UPDATE epics SET
-    assigned_skills = '["api-design", "testing-strategy"]',
-    skill_order = '["api-design", "testing-strategy"]',
-    current_skill = 'api-design'
-WHERE id = 'epic-001';
+ohno has no skill-specific fields, so track skill assignments on the entities it does have — never write ohno's internal database directly.
 
--- Track skill assignment at story level
-UPDATE stories SET
-    assigned_skill = 'api-design'
-WHERE id = 'story-001-01';
+- **PROJECT.md is the source of truth** for skill assignments — keep its "Skill Assignments" table (see below) up to date.
+- **Epic descriptions carry the routing state.** When planning assigns skills, append a line via `mcp__ohno__update_epic`:
 
--- Query features by skill
-SELECT e.id, e.title, e.priority
-FROM epics e
-WHERE e.assigned_skills LIKE '%api-design%'
-  AND e.current_skill = 'api-design'
-ORDER BY
-    CASE e.priority
-        WHEN 'P0' THEN 0
-        WHEN 'P1' THEN 1
-        WHEN 'P2' THEN 2
-        ELSE 3
-    END;
+```
+Skills: api-design → testing-strategy | Current: api-design
+```
+
+- **Query features by skill** with the CLI (global `--json` flag):
+
+```bash
+# Epics currently routed to api-design
+npx @stevestomp/ohno-cli epics --json | node -e '
+const epics = JSON.parse(require("fs").readFileSync(0, "utf8"));
+for (const e of epics) {
+  if ((e.description || "").includes("Current: api-design")) {
+    console.log(`${e.id}\t${e.priority}\t${e.title}`);
+  }
+}'
 ```
 
 ### Skill Transition
 
-```sql
--- When skill completes, move to next
-UPDATE epics SET
-    current_skill = (
-        SELECT json_extract(skill_order, '$[' || (
-            SELECT instr(skill_order, current_skill) + length(current_skill)
-        ) || ']')
-    ),
-    updated_at = datetime('now')
-WHERE id = 'epic-001';
-
--- Or explicitly
-UPDATE epics SET
-    current_skill = 'testing-strategy',  -- was 'api-design'
-    updated_at = datetime('now')
-WHERE id = 'epic-001';
-```
+When a skill completes its work on an epic, advance the `Current:` marker to the next skill in the `Skills:` chain via `mcp__ohno__update_epic` (or remove the marker when the chain is done), and update the PROJECT.md skill assignments table in the same pass.
 
 ---
 
@@ -203,70 +182,17 @@ WHERE id = 'epic-001';
 
 When a skill is invoked, it should:
 
-```python
-def get_my_work(skill_name: str, db_path: str) -> list:
-    """Get features assigned to this skill."""
-    
-    conn = sqlite3.connect(db_path)
-    
-    # Get epics where this skill is current
-    epics = conn.execute("""
-        SELECT id, title, priority, description
-        FROM epics
-        WHERE current_skill = ?
-          AND status != 'completed'
-        ORDER BY 
-            CASE priority 
-                WHEN 'P0' THEN 0 
-                WHEN 'P1' THEN 1 
-                WHEN 'P2' THEN 2 
-                ELSE 3 
-            END
-    """, (skill_name,)).fetchall()
-    
-    return [dict(e) for e in epics]
-```
+1. Read `.claude/PROJECT.md` and find its rows in the "Skill Assignments" table.
+2. Confirm against ohno — `mcp__ohno__get_epics` (or the CLI query above), filtering for epics whose description lists it as `Current:` and whose status isn't done.
+3. Work highest priority first (P0 → P1 → P2 → P3).
 
 ### Marking Work Complete
 
-When a skill finishes:
+When a skill finishes an epic:
 
-```python
-def complete_skill_work(skill_name: str, epic_id: str, db_path: str):
-    """Mark skill as complete, transition to next."""
-    
-    conn = sqlite3.connect(db_path)
-    
-    # Get skill order
-    result = conn.execute("""
-        SELECT skill_order, current_skill
-        FROM epics WHERE id = ?
-    """, (epic_id,)).fetchone()
-    
-    skill_order = json.loads(result['skill_order'])
-    current_idx = skill_order.index(skill_name)
-    
-    # Move to next skill or mark complete
-    if current_idx + 1 < len(skill_order):
-        next_skill = skill_order[current_idx + 1]
-        conn.execute("""
-            UPDATE epics SET
-                current_skill = ?,
-                updated_at = datetime('now')
-            WHERE id = ?
-        """, (next_skill, epic_id))
-    else:
-        # All skills complete
-        conn.execute("""
-            UPDATE epics SET
-                current_skill = NULL,
-                status = 'completed',
-                updated_at = datetime('now')
-            WHERE id = ?
-        """, (epic_id,))
-    
-    conn.commit()
-```
+1. Advance the `Current:` marker to the next skill in the `Skills:` chain via `mcp__ohno__update_epic` — or, if it was the last skill, remove the marker.
+2. Log what was done via `mcp__ohno__add_task_activity` on the affected tasks.
+3. Update PROJECT.md ("Skill Assignments" table and "Next Actions").
 
 ---
 
@@ -311,47 +237,21 @@ After those complete:
 
 ## Automation Helpers
 
-### SQL: Pending Work by Skill
+### Pending Work by Skill
 
-```sql
--- Get all pending work grouped by skill
-SELECT 
-    e.current_skill as skill,
-    e.priority,
-    COUNT(*) as feature_count,
-    GROUP_CONCAT(e.id) as features
-FROM epics e
-WHERE e.current_skill IS NOT NULL
-  AND e.status != 'completed'
-GROUP BY e.current_skill, e.priority
-ORDER BY 
-    CASE e.priority 
-        WHEN 'P0' THEN 0 
-        WHEN 'P1' THEN 1 
-        WHEN 'P2' THEN 2 
-        ELSE 3 
-    END,
-    e.current_skill;
-```
-
-### SQL: Skill Progress
-
-```sql
--- Track how much work each skill has completed
-SELECT 
-    skill,
-    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-    SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as in_progress,
-    SUM(CASE WHEN status = 'planned' THEN 1 ELSE 0 END) as pending,
-    COUNT(*) as total
-FROM (
-    SELECT 
-        e.id,
-        e.status,
-        json_each.value as skill
-    FROM epics e, json_each(e.assigned_skills)
-) grouped
-GROUP BY skill;
+```bash
+# Group open epics by their Current: skill marker
+npx @stevestomp/ohno-cli epics --json | node -e '
+const epics = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const groups = {};
+for (const e of epics) {
+  const m = (e.description || "").match(/Current: ([a-z-]+)/);
+  if (!m || e.status === "done") continue;
+  (groups[m[1]] ||= []).push(`${e.id} (${e.priority})`);
+}
+for (const [skill, features] of Object.entries(groups)) {
+  console.log(`${skill}: ${features.join(", ")}`);
+}'
 ```
 
 ### Bash: Check Next Skill
@@ -360,20 +260,18 @@ GROUP BY skill;
 #!/bin/bash
 # next-skill.sh - Determine which skill to run next
 
-DB_PATH=".claude/tasks.db"
-
 echo "=== Next Skill to Run ==="
 
-# Get P0 features with pending skills
-sqlite3 "$DB_PATH" "
-SELECT current_skill, GROUP_CONCAT(id, ', ') as features
-FROM epics
-WHERE current_skill IS NOT NULL
-  AND status != 'completed'
-  AND priority = 'P0'
-GROUP BY current_skill
-LIMIT 1;
-"
+# First open P0 epic with a pending skill marker
+npx @stevestomp/ohno-cli epics --json | node -e '
+const epics = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const next = epics.find(e => e.priority === "P0" && e.status !== "done" &&
+  /Current: [a-z-]+/.test(e.description || ""));
+if (next) {
+  console.log(`${next.description.match(/Current: ([a-z-]+)/)[1]} — ${next.id}: ${next.title}`);
+} else {
+  console.log("No pending P0 skill work");
+}'
 ```
 
 ---
@@ -418,20 +316,18 @@ Pure configuration or documentation features:
 ## Integration Checklist
 
 ### planning Output
-- [ ] Every feature has `assigned_skills`
-- [ ] Every feature has `skill_order`
-- [ ] `current_skill` set to first in order
+- [ ] Every feature has assigned skills and a skill order
+- [ ] Each epic's `Skills:` line sets `Current:` to the first skill in its chain (via `mcp__ohno__update_epic`)
 - [ ] PROJECT.md includes skill assignments section
-- [ ] features.json includes skill_summary
 
 ### Skill Invocation
 - [ ] Skill reads PROJECT.md first
-- [ ] Skill queries tasks.db for assigned work
+- [ ] Skill queries ohno for assigned work (`mcp__ohno__get_epics` / `npx @stevestomp/ohno-cli epics --json`)
 - [ ] Skill updates status when complete
 - [ ] Skill transitions to next skill in order
 
 ### feature-audit Audit
 - [ ] Runs after all skills complete
 - [ ] Checks implementation matches assignments
-- [ ] Updates audit_level in tasks.db
+- [ ] Records audit results in ohno (see feature-audit's gap-analysis reference)
 - [ ] Adds remediation tasks if gaps found

--- a/plugins/pokayokay/skills/security-audit/SKILL.md
+++ b/plugins/pokayokay/skills/security-audit/SKILL.md
@@ -23,7 +23,7 @@ Systematic security review for application code, dependencies, and configuration
 ## When NOT to Use
 
 - **Designing new auth flows** — Use `api-design` for designing OAuth2/JWT endpoints from scratch
-- **Performance issues** — Use `performance-optimization` even if caused by auth overhead
+- **Performance issues** — Use `observability` to diagnose latency and resource problems, even if caused by auth overhead
 - **CI/CD pipeline security** — Use `ci-cd` for pipeline hardening (secret management, permissions)
 
 ## Key Principles

--- a/plugins/pokayokay/skills/session-review/SKILL.md
+++ b/plugins/pokayokay/skills/session-review/SKILL.md
@@ -2,7 +2,7 @@
 name: session-review
 description: Use after completing work sessions to analyze agent behavior patterns, prepare session handoffs for continuity, document completed work, identify blockers, or preserve context for the next session.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent
+allowed-tools: Read, Grep, Glob, Bash, Agent, Write, mcp__ohno__set_handoff_notes, mcp__ohno__get_task_handoff, mcp__ohno__get_session_context, mcp__ohno__add_task_activity
 ---
 
 # Session Review & Handoff

--- a/plugins/pokayokay/skills/session-review/SKILL.md
+++ b/plugins/pokayokay/skills/session-review/SKILL.md
@@ -2,7 +2,7 @@
 name: session-review
 description: Use after completing work sessions to analyze agent behavior patterns, prepare session handoffs for continuity, document completed work, identify blockers, or preserve context for the next session.
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Bash, Agent, Write, mcp__ohno__set_handoff_notes, mcp__ohno__get_task_handoff, mcp__ohno__get_session_context, mcp__ohno__add_task_activity
+allowed-tools: Read, Grep, Glob, Bash, Agent, Write, mcp__ohno__set_handoff_notes, mcp__ohno__get_task_handoff, mcp__ohno__get_session_context, mcp__ohno__add_task_activity, mcp__plugin_pokayokay_ohno__set_handoff_notes, mcp__plugin_pokayokay_ohno__get_task_handoff, mcp__plugin_pokayokay_ohno__get_session_context, mcp__plugin_pokayokay_ohno__add_task_activity
 ---
 
 # Session Review & Handoff

--- a/plugins/pokayokay/skills/session-review/references/analysis-scripts.md
+++ b/plugins/pokayokay/skills/session-review/references/analysis-scripts.md
@@ -99,117 +99,51 @@ git log --name-only --format="" --since="$SINCE" | \
     sort | uniq -c | sort -rn | head -20
 ```
 
-## Database Analysis
+## Task Analysis (ohno)
+
+Task state lives in ohno (`.ohno/`) — query it via the CLI's global `--json` flag or MCP tools; never read ohno's internal database directly.
 
 ### Task Completion Metrics
 
-```sql
--- task-metrics.sql
--- Run against .claude/tasks.db
+```bash
+#!/bin/bash
+# task-metrics.sh - Completion stats from ohno
 
--- Overall completion stats
-SELECT 
-    COUNT(*) as total_tasks,
-    SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as completed,
-    SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as in_progress,
-    SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) as blocked,
-    ROUND(100.0 * SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) / COUNT(*), 1) as completion_pct
-FROM tasks;
+npx @stevestomp/ohno-cli tasks --json | node -e '
+const tasks = JSON.parse(require("fs").readFileSync(0, "utf8"));
 
--- Completion by task type
-SELECT 
-    task_type,
-    COUNT(*) as total,
-    SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as completed,
-    ROUND(100.0 * SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) / COUNT(*), 1) as pct
-FROM tasks
-GROUP BY task_type
-ORDER BY total DESC;
+// Overall completion stats
+const count = s => tasks.filter(t => t.status === s).length;
+console.log("=== Overall ===");
+console.log(`Total: ${tasks.length}`);
+console.log(`Done: ${count("done")}, In progress: ${count("in_progress")}, Blocked: ${count("blocked")}`);
+console.log(`Completion: ${(100 * count("done") / (tasks.length || 1)).toFixed(1)}%`);
 
--- Estimate accuracy by type
-SELECT 
-    task_type,
-    COUNT(*) as tasks,
-    ROUND(AVG(estimate_hours), 1) as avg_estimate,
-    ROUND(AVG(
-        CASE WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
-        THEN (julianday(completed_at) - julianday(started_at)) * 24
-        ELSE NULL END
-    ), 1) as avg_actual,
-    ROUND(
-        AVG(
-            CASE WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
-            THEN (julianday(completed_at) - julianday(started_at)) * 24
-            ELSE NULL END
-        ) / NULLIF(AVG(estimate_hours), 0),
-    2) as accuracy_ratio
-FROM tasks
-WHERE status = 'done'
-GROUP BY task_type;
-
--- Tasks that took longest relative to estimate
-SELECT 
-    id,
-    title,
-    task_type,
-    estimate_hours,
-    ROUND((julianday(completed_at) - julianday(started_at)) * 24, 1) as actual_hours,
-    ROUND(
-        (julianday(completed_at) - julianday(started_at)) * 24 / NULLIF(estimate_hours, 0),
-    1) as ratio
-FROM tasks
-WHERE status = 'done' 
-    AND completed_at IS NOT NULL 
-    AND started_at IS NOT NULL
-ORDER BY ratio DESC
-LIMIT 10;
+// Completion by task type
+console.log("\n=== By Task Type ===");
+const byType = {};
+for (const t of tasks) {
+  const g = (byType[t.task_type] ||= { total: 0, done: 0 });
+  g.total++;
+  if (t.status === "done") g.done++;
+}
+for (const [type, g] of Object.entries(byType)) {
+  console.log(`${type}: ${g.done}/${g.total} (${(100 * g.done / g.total).toFixed(1)}%)`);
+}'
 ```
 
-### Dependency Analysis
+### Blocked Task Analysis
 
-```sql
--- dependency-analysis.sql
-
--- Find tasks that blocked others
-SELECT 
-    t.id,
-    t.title,
-    t.status,
-    COUNT(d.blocked_task_id) as blocks_count
-FROM tasks t
-JOIN dependencies d ON t.id = d.blocker_task_id
-GROUP BY t.id
-ORDER BY blocks_count DESC;
-
--- Find bottleneck paths (tasks with most downstream dependencies)
-WITH RECURSIVE dependency_chain AS (
-    SELECT 
-        blocker_task_id as root,
-        blocked_task_id as task_id,
-        1 as depth
-    FROM dependencies
-    
-    UNION ALL
-    
-    SELECT 
-        dc.root,
-        d.blocked_task_id,
-        dc.depth + 1
-    FROM dependency_chain dc
-    JOIN dependencies d ON dc.task_id = d.blocker_task_id
-    WHERE dc.depth < 10
-)
-SELECT 
-    root,
-    t.title,
-    COUNT(DISTINCT task_id) as downstream_tasks,
-    MAX(depth) as max_chain_length
-FROM dependency_chain dc
-JOIN tasks t ON dc.root = t.id
-GROUP BY root
-ORDER BY downstream_tasks DESC
-LIMIT 10;
+```bash
+# Tasks currently blocked, with reasons
+npx @stevestomp/ohno-cli tasks --json | node -e '
+const tasks = JSON.parse(require("fs").readFileSync(0, "utf8"));
+for (const t of tasks.filter(t => t.status === "blocked")) {
+  console.log(`${t.id}: ${t.title} — ${t.blocked_reason || "no reason recorded"}`);
+}'
 ```
+
+In an MCP session, `mcp__ohno__get_project_status` and `mcp__ohno__get_blocked_tasks` return the same data without shell scripting, and `mcp__ohno__get_task_dependencies` shows which tasks blocked others.
 
 ## Session Log Analysis
 
@@ -464,12 +398,12 @@ echo "## Git Analysis" > "$REPORT_FILE"
 echo >> "$REPORT_FILE"
 ./git-stats.sh "1 week ago" >> "$REPORT_FILE"
 
-# Database analysis
-if [ -f "$CLAUDE_DIR/tasks.db" ]; then
+# Task analysis (ohno)
+if [ -d "$PROJECT_DIR/.ohno" ]; then
     echo >> "$REPORT_FILE"
     echo "## Task Analysis" >> "$REPORT_FILE"
     echo >> "$REPORT_FILE"
-    sqlite3 -header -column "$CLAUDE_DIR/tasks.db" < task-metrics.sql >> "$REPORT_FILE"
+    ./task-metrics.sh >> "$REPORT_FILE"
 fi
 
 # Session analysis

--- a/plugins/pokayokay/skills/session-review/references/pattern-library.md
+++ b/plugins/pokayokay/skills/session-review/references/pattern-library.md
@@ -212,7 +212,7 @@ def analyze_progress_patterns(progress_md: str) -> dict:
 **Description**: Adding features not in original spec
 
 **Signals**:
-- Tasks appear that weren't in features.json
+- Tasks appear that weren't in the plan (ohno backlog)
 - Estimates balloon mid-project
 - "While I'm here..." in logs
 

--- a/plugins/pokayokay/skills/spike/SKILL.md
+++ b/plugins/pokayokay/skills/spike/SKILL.md
@@ -12,7 +12,7 @@ Structured technical investigation to reduce uncertainty. Answer specific questi
 ## Key Principles
 
 - Every spike answers a specific, measurable question
-- Strict time-box (default 4h) — produce a decision at the end, even if incomplete
+- Strict time-box (default 2h) — produce a decision at the end, even if incomplete
 - Output is a decision (GO/NO-GO/PIVOT/MORE-INFO), not a general exploration
 - Create follow-up tasks from findings, not just a report
 
@@ -36,7 +36,7 @@ Structured technical investigation to reduce uncertainty. Answer specific questi
 - **Decision**: GO, NO-GO, PIVOT, or MORE-INFO
 - **Evidence**: What was tested, results observed
 - **Follow-up tasks**: Created in ohno if GO
-- **Report**: Saved to `.claude/spikes/[name]-[date].md`
+- **Report**: Saved to `.claude/spikes/[date]-[slug].md`
 
 ## References
 

--- a/plugins/pokayokay/skills/spike/references/output-templates.md
+++ b/plugins/pokayokay/skills/spike/references/output-templates.md
@@ -336,7 +336,7 @@ For stakeholder communication (< 100 words):
 ## Spike Summary: [Title]
 
 **Question**: [One line]
-**Answer**: [GO/NO-GO/PIVOT] — [One sentence]
+**Answer**: [GO/NO-GO/PIVOT/MORE-INFO] — [One sentence]
 **Key Finding**: [Most important discovery]
 **Next Step**: [Immediate action]
 **Full Report**: `.claude/spikes/[name].md`

--- a/plugins/pokayokay/skills/spike/references/output-templates.md
+++ b/plugins/pokayokay/skills/spike/references/output-templates.md
@@ -36,7 +36,7 @@ Templates for consistent, actionable spike documentation. Keep reports concise (
 | [Metric] | [Target] | [Result] |
 
 ## Proof of Concept
-**Location**: `.claude/spikes/[name]/`
+**Location**: `.claude/spikes/[date]-[slug]/`
 
 [Brief code snippet or reference to key files]
 
@@ -90,7 +90,7 @@ Can [technology] [capability] within [constraint]?
 - [Libraries, services, or setup needed]
 
 ## Proof of Concept
-**Location**: `.claude/spikes/[name]/`
+**Location**: `.claude/spikes/[date]-[slug]/`
 
 Key patterns demonstrated:
 - [Pattern 1]
@@ -200,7 +200,7 @@ How do we integrate with [service] for [purpose]?
 - [Undocumented quirk 2]
 
 ## Client Code
-**Location**: `.claude/spikes/[name]/`
+**Location**: `.claude/spikes/[date]-[slug]/`
 
 Files created:
 - `client.ts` - API client
@@ -339,7 +339,7 @@ For stakeholder communication (< 100 words):
 **Answer**: [GO/NO-GO/PIVOT/MORE-INFO] — [One sentence]
 **Key Finding**: [Most important discovery]
 **Next Step**: [Immediate action]
-**Full Report**: `.claude/spikes/[name].md`
+**Full Report**: `.claude/spikes/[date]-[slug].md`
 ```
 
 ---
@@ -366,7 +366,7 @@ For stakeholder communication (< 100 words):
 When marking spike done in ohno:
 
 ```
-[DECISION] - [One-line summary]. See .claude/spikes/[name].md
+[DECISION] - [One-line summary]. See .claude/spikes/[date]-[slug].md
 
 Created follow-ups:
 - task-xxx: [title]

--- a/plugins/pokayokay/skills/work-session/SKILL.md
+++ b/plugins/pokayokay/skills/work-session/SKILL.md
@@ -67,5 +67,5 @@ Orchestrate AI-assisted development with configurable human control, using ohno 
 
 ## Runtime Notes
 
-- **Claude Code**: the coordinator dispatches yokay-brainstormer, yokay-design-reviewer, yokay-implementer, yokay-fixer, yokay-spec-reviewer, yokay-quality-reviewer, yokay-browser-verifier, and yokay-test-runner via the Task tool with `subagent_type: "pokayokay:yokay-<name>"`, as described in [dispatch-preparation.md](references/dispatch-preparation.md).
+- **Claude Code**: the coordinator dispatches yokay-brainstormer, yokay-design-reviewer, yokay-implementer, yokay-fixer, yokay-spec-reviewer, yokay-quality-reviewer, yokay-browser-verifier, and yokay-auditor via the Task tool with `subagent_type: "pokayokay:yokay-<name>"`, as described in [dispatch-preparation.md](references/dispatch-preparation.md).
 - **Codex**: there is no subagent dispatch. Run the pipeline inline in the current session — for each stage, read the corresponding `agents/yokay-<name>.md` and follow its Behavioral Defaults, Critical Rules, and Output Contract. Execute stages (design review (conditional) → implement → spec review → quality review) as separate, sequential passes; do not skip review stages because dispatch is unavailable. Parallel batch execution ([parallel-execution.md](references/parallel-execution.md)) is Claude Code-only — process tasks sequentially on Codex.

--- a/plugins/pokayokay/skills/work-session/references/bug-fix-pipeline.md
+++ b/plugins/pokayokay/skills/work-session/references/bug-fix-pipeline.md
@@ -68,6 +68,14 @@ Place the test alongside existing tests for the affected module.
 
 ## Step 3: Dispatch Implementer
 
+**First, record the review baseline.** Before dispatching the implementer, capture the pre-implementation commit in the task's working directory (worktree or project root):
+
+```bash
+BASE_COMMIT=$(git rev-parse HEAD)
+```
+
+Carry this value forward — chain-state or in-context — to Step 6, where it fills `{BASE_COMMIT}` in both review templates (their primary `git diff {BASE_COMMIT}` verification commands depend on it, and a missing value makes reviewers return BLOCKED or fall back to an unintended baseline).
+
 Use template: `agents/templates/implementer-prompt.md`
 Agent: `yokay-implementer`
 

--- a/plugins/pokayokay/skills/work-session/references/bug-fix-pipeline.md
+++ b/plugins/pokayokay/skills/work-session/references/bug-fix-pipeline.md
@@ -152,7 +152,7 @@ Fill templates with (cover EVERY placeholder — a literal `{...}` in a dispatch
 - `{IMPLEMENTATION_SUMMARY}`: from the implementer's ohno handoff (`get_task_handoff(task_id)`) — the inline report is minimal
 - `{FILES_CHANGED}`: from implementer's handoff
 - `{COMMIT_INFO}`: from implementer's commit (hash + message)
-- `{COMMIT_HASH}`: bare commit hash — used in the templates' `git diff` verification commands
+- `{BASE_COMMIT}`: commit recorded by the coordinator before implementer dispatch — primary baseline for the templates' `git diff` verification commands (working-tree-inclusive)
 - `{APPROACH}` (quality template only): `None — design review was skipped`
 - `{WORKING_DIRECTORY}`: task's worktree path or project root
 

--- a/plugins/pokayokay/skills/work-session/references/chain-state.md
+++ b/plugins/pokayokay/skills/work-session/references/chain-state.md
@@ -1,0 +1,310 @@
+# Chain State & Headless Sessions
+
+Single source for headless configuration, the chain state file contract,
+proactive context shutdown, and the chain completion audit. `/work` (work.md)
+summarizes each of these and points here.
+
+## Headless Configuration
+
+Headless mode enables automatic session chaining when context fills up.
+
+### Configuration
+
+Read headless config from `.pokayokay/config.json` when present, falling back to `.claude/pokayokay.json` for existing Claude Code projects:
+
+```json
+{
+  "headless": {
+    "max_chains": 10,
+    "report": "on_complete",
+    "notify": "terminal"
+  }
+}
+```
+
+| Setting | Values | Default | Description |
+|---------|--------|---------|-------------|
+| `max_chains` | 1-50 | 10 | Maximum sessions to chain before stopping |
+| `report` | `on_complete`, `on_failure`, `always`, `never` | `on_complete` | When to generate chain report |
+| `notify` | `terminal`, `none` | `terminal` | How to notify on chain completion |
+
+### Scope Requirement
+
+**Headless mode requires explicit scope to prevent runaway sessions.**
+
+When running headless (auto/unattended mode or `--continue` from chain):
+- `--epic <id>`: Only work on tasks within the specified epic
+- `--story <id>`: Only work on tasks within the specified story
+- `--all`: Explicitly allow working on all available tasks
+
+If no scope is provided in auto/unattended/headless mode, PAUSE and ask:
+```markdown
+Headless/auto/unattended mode requires a scope to prevent runaway sessions.
+
+Which tasks should this session work on?
+  1. --epic <id>  (work within a specific epic)
+  2. --story <id> (work within a specific story)
+  3. --all        (all available tasks)
+```
+
+### Scope Filtering
+
+When scope is set, filter `get_next_task` and `get_next_batch` results:
+
+```python
+def get_scoped_tasks(scope):
+    if scope.type == "epic":
+        return get_tasks(epic_id=scope.id, status="todo")
+    elif scope.type == "story":
+        return get_tasks(story_id=scope.id, status="todo")  # via story filter
+    else:  # "all"
+        return get_next_batch()
+```
+
+## Initializing Chain State (Session Start)
+
+When starting a NEW auto or unattended session with scope (not `--continue`), write the chain state file
+so that SessionEnd hooks can spawn continuation sessions:
+
+```
+Write .pokayokay/pokayokay-chain-state.json:
+{
+  "chain_id": "chain-<current-unix-timestamp>",
+  "chain_index": 0,
+  "scope_type": "<epic|story|all>",
+  "scope_id": "<id or empty string>",
+  "tasks_completed": 0,
+  "adaptive_n": 2,
+  "batches_completed": 0,
+  "batches_failed": 0,
+  "failed_tasks": [],
+  "conflict_tasks": [],
+  "last_session_summary": ""
+}
+```
+
+Use the Write tool. Generate chain_id from current unix timestamp.
+
+**Skip this step** if:
+- Mode is NOT auto/unattended (supervised/semi-auto don't chain)
+- No scope is set (chaining requires scope)
+- `--continue` flag is set (state file already exists from previous session)
+
+## Proactive Context Shutdown
+
+When session chaining is active (chain state file exists), the coordinator MUST
+proactively end the session when context pressure is detected — **before** quality
+degrades from repeated compaction.
+
+### Detection
+
+Context pressure is detected when **any** of these occur:
+1. The active runtime compacts the conversation (for example, Claude Code shows "Compacting conversation..." in output)
+2. A system reminder mentions context limits
+3. You notice repeated information loss from prior context
+
+### Behavior
+
+When context pressure is detected during a chained session:
+
+1. **Stop dispatching new tasks** — do not start another batch
+2. **Wait for in-flight agents** — let current implementers finish (they have their own context)
+3. **Save WIP** for any incomplete work:
+   ```
+   For each in-progress task with uncommitted changes:
+     update_task_wip(task_id, { files_modified, last_commit, uncommitted_changes, next_step })
+   ```
+4. **Save coordinator state** to chain state file:
+   ```
+   Read existing .pokayokay/pokayokay-chain-state.json, falling back to .claude/pokayokay-chain-state.json
+   Update with:
+     adaptive_n: current parallel count
+     batches_completed: count
+     batches_failed: count
+     failed_tasks: [task IDs that failed/blocked]
+     conflict_tasks: [task IDs with git conflicts]
+     last_session_summary: "Completed X tasks, Y failed, Z conflicts"
+   Write back to .pokayokay/pokayokay-chain-state.json
+   ```
+5. **Log session summary**:
+   ```
+   add_task_activity(task_id, "note", "Session ending: context pressure detected, chaining to next session")
+   ```
+6. **End the session** — output a brief summary and stop. This triggers:
+   - SessionEnd hook → bridge.py reads chain state → session-chain.sh spawns/prepares the next runtime session
+
+### Why Proactive?
+
+Without proactive shutdown:
+- Context fills → Claude Code compacts → quality degrades → compacts again → eventually dies
+- Each compaction loses coordinator context (task state, batch tracking, decisions)
+- Subagents returning to a degraded coordinator get confused
+
+With proactive shutdown:
+- First compaction detected → graceful exit → fresh session chains with full context
+- No quality degradation
+- WIP preserved for seamless resume
+
+### Non-Chained Sessions
+
+In supervised or semi-auto sessions (no chain state file), compaction is handled
+normally by the active runtime. The coordinator does NOT need to proactively end — the user
+is present and can decide.
+
+## Session Chaining (Session End)
+
+When a session reaches context limits (or ends with remaining work in scope):
+
+1. Save current WIP to ohno (automatic via hooks)
+2. Generate chain report if configured
+3. Exit with chain metadata:
+   ```json
+   {
+     "chain_id": "chain-abc123",
+     "chain_index": 3,
+     "max_chains": 10,
+     "scope": {"type": "epic", "id": "epic-abc123"},
+     "tasks_completed": 5,
+     "tasks_remaining": 8
+   }
+   ```
+4. SessionEnd hook spawns or prepares the next session using the active runtime:
+   ```bash
+   # Claude Code
+   claude -p "/work --continue --epic epic-abc123"
+
+   # Codex
+   codex --prompt="/work --continue --epic epic-abc123"
+   ```
+
+In detail, on SessionEnd:
+
+1. SessionEnd hook calls `session-chain.sh`
+2. Script checks remaining ready tasks via ohno
+3. If tasks remain and chain limit not reached:
+   - Spawns/prepares the next session using the active runtime, for example `claude -p "/work --continue <scope-flag>"` or `codex --prompt="/work --continue <scope-flag>"`
+4. If chain complete or limit reached:
+   - Generates report to `.ohno/reports/chain-{id}-report.md`
+   - Notifies via configured method
+   - Deletes chain state file
+
+### Chain Reporting
+
+On chain completion (all tasks done or max_chains reached), generate report:
+
+```
+.ohno/reports/chain-{id}-report.md
+
+# Session Chain Report
+- Chain ID: chain-abc123
+- Sessions: 4
+- Scope: epic-4fcd1e3c (Context Efficiency Redesign)
+- Tasks completed: 12
+- Tasks failed: 1 (task-xyz: test failures)
+- Tasks remaining: 2
+- Total duration: ~45 minutes
+- Decisions made: [extracted from task handoffs]
+```
+
+Report is generated BEFORE memory decay compacts handoff details.
+
+## Chain State File
+
+Chain state is communicated between the coordinator and hooks via `.pokayokay/pokayokay-chain-state.json`, with `.claude/pokayokay-chain-state.json` retained as a legacy fallback.
+
+**The coordinator MUST write this file at session start** when running auto mode with scope.
+Use the Write tool to create it:
+
+```json
+{
+  "chain_id": "chain-<unix-timestamp>",
+  "chain_index": 0,
+  "scope_type": "all",
+  "scope_id": "",
+  "tasks_completed": 0,
+  "adaptive_n": 2,
+  "batches_completed": 0,
+  "batches_failed": 0,
+  "failed_tasks": [],
+  "conflict_tasks": [],
+  "last_session_summary": ""
+}
+```
+
+### Chain State Fields
+
+- `chain_id`: Generate as `chain-<unix-timestamp>` (e.g., `chain-1738764000`)
+- `chain_index`: Start at 0, auto-incremented by bridge.py on each chain
+- `scope_type`: "epic", "story", or "all" (from `--epic`, `--story`, or `--all` flag)
+- `scope_id`: The epic/story ID (empty string for "all")
+- `tasks_completed`: Starts at 0, auto-incremented by bridge.py on each task completion
+- `adaptive_n`: Current parallel count (written by coordinator before shutdown)
+- `batches_completed`: Successful batch count (for adaptive sizing decisions)
+- `batches_failed`: Failed batch count (for adaptive sizing decisions)
+- `failed_tasks`: Task IDs that failed or got blocked (skip on resume)
+- `conflict_tasks`: Task IDs with git conflicts (flag for manual resolution)
+- `last_session_summary`: Brief summary of what the last session accomplished
+
+**When `--continue`**: Read the existing state file. Do NOT overwrite it — bridge.py
+already incremented `chain_index` and tracks `tasks_completed`. Restore coordinator state
+from extended fields (`adaptive_n`, `failed_tasks`, etc.).
+
+**When NOT auto or no scope**: Do NOT write the state file. Non-chaining sessions
+should not have a state file.
+
+Bridge.py handles:
+- Reading the state file on SessionEnd to pass to session-chain.sh
+- Incrementing `tasks_completed` on each task completion
+- Incrementing `chain_index` when spawning the next session
+- Deleting the state file when the chain completes or hits the limit
+
+## Chain Completion Audit
+
+When all tasks in scope are done, the chain runs a completeness audit before declaring success.
+
+### How It Works
+
+1. `session-chain.sh` detects `READY_COUNT == 0` but `CHAIN_AUDITED != true`
+2. Returns `audit_pending` instead of `complete`
+3. `bridge.py` sets `chain_state.audit_pending = true` (does NOT delete chain state)
+4. On next session start (via chain continue), coordinator detects `audit_pending`:
+
+**Coordinator audit logic (run at session start when `--continue` and audit_pending):**
+
+```
+Read chain state → check audit_pending == true
+
+If audit_pending:
+  1. Find the concept doc / PRD:
+     - Check docs/plans/*.md, docs/concepts/*.md
+     - Check epic description if scope is epic
+     - Check PROJECT.md
+  2. Dispatch `pokayokay:yokay-auditor` (Task tool subagent_type):
+     - Pass: concept doc content + scope info
+     - Instruction: "Verify all requirements are implemented. Return PASS or FAIL with gap list."
+  3. Process result:
+     - PASS:
+       - Set chain_state.audit_passed = true
+       - Set chain_state.audit_pending = false
+       - Save chain state
+       - Session ends → session-chain.sh sees CHAIN_AUDITED=true → "complete"
+     - FAIL with gaps:
+       - Create remediation tasks in ohno for each gap
+       - Set chain_state.audit_pending = false (audit ran, even if failed)
+       - Continue working on remediation tasks
+       - When those complete, audit runs again (next chain end)
+```
+
+### Audit Tracking Fields
+
+The following fields are added to the chain state for audit tracking:
+
+```json
+{
+  "audit_pending": false,
+  "audit_passed": false
+}
+```
+
+- `audit_pending`: Set to `true` by bridge.py when all tasks done but audit not yet run
+- `audit_passed`: Set to `true` by coordinator when audit passes. Passed to session-chain.sh as `CHAIN_AUDITED`

--- a/plugins/pokayokay/skills/work-session/references/dispatch-errors.md
+++ b/plugins/pokayokay/skills/work-session/references/dispatch-errors.md
@@ -29,4 +29,21 @@ Recovery procedures when dispatch components fail.
 
 **Task tool unavailable**: Coordinator implements directly (fallback mode). On Codex this is the normal path — run the stage inline per the agent's definition.
 
-**Subagent returns error**: Analyze error cause, fix prerequisites, re-dispatch with corrections.
+### Dispatch Failure Protocol
+
+Classify every failed or suspect dispatch into one of four classes and apply the mandated behavior:
+
+| Class | Symptom | Mandated behavior |
+|-------|---------|-------------------|
+| **(a) Tool error / timeout** | Task tool returns an error or times out before a report arrives | Retry the dispatch ONCE. On second failure, `mcp__ohno__set_blocker(task_id, "agent dispatch failed: tool error/timeout")` and move to the next task. |
+| **(b) Empty / no verdict token** | Report is empty, or contains no recognizable status token (`Status:`, `VERDICT:`, `PASS`, `FAIL`, `BLOCKED`) | Retry the dispatch ONCE, prefixing the prompt with: "Your previous dispatch produced no usable report; end with the required status line". On second failure, `mcp__ohno__set_blocker(task_id, "agent dispatch failed: no usable report")` and move on. |
+| **(c) Questions only** | Report contains only questions (e.g. the brainstormer's `### Open Questions`) with no usable result | Answer from the task description, story context, and handoff notes, then re-dispatch with `## Answers to Your Questions` appended to the prompt. Mode-aware per [dispatch-preparation.md](dispatch-preparation.md) Step 2: in supervised/semi-auto, surface unanswerable questions at the human checkpoint; in auto/unattended, log them as assumptions and proceed. |
+| **(d) Success claimed, no commit** | Report claims success but `git log --oneline -1` shows no new commit | Inspect the worktree (`git status`, `git log --oneline -5`) and re-dispatch with resume context built from the ACTUAL state (files present, last real commit, what remains). Never trust the claim over the repository. |
+
+**Hard rule**: A task NEVER remains `in_progress` after its dispatch concludes —
+it ends the cycle `done`, `blocked`, or back to `todo`.
+
+This protocol complements (does not replace) the existing recovery paths:
+crashed sessions with stale `in_progress` tasks are handled by
+`hooks/actions/recover.sh` (WIP saved, crash note folded in), and interrupted
+work resumes via `/work --continue` (work.md "Resume Check").

--- a/plugins/pokayokay/skills/work-session/references/dispatch-preparation.md
+++ b/plugins/pokayokay/skills/work-session/references/dispatch-preparation.md
@@ -55,7 +55,7 @@ Assemble context from: (1) story context if task belongs to story, (2) task's ow
 
 ## Step 2: Brainstorm Gate (Conditional)
 
-**Agent**: `yokay-brainstormer` | **Template**: `agents/templates/brainstorm-prompt.md`
+**Agent**: `pokayokay:yokay-brainstormer` | **Template**: `agents/templates/brainstorm-prompt.md`
 
 ### Trigger Conditions
 
@@ -84,16 +84,36 @@ Even when AC exists, check quality before dispatching. **Route through brainstor
 
 **Quick heuristic**: If you could write a test from the criterion text alone, it passes. If you'd need to guess what to test, it fails.
 
+### Dispatching the Brainstormer
+
+```
+Task tool:
+  subagent_type: "pokayokay:yokay-brainstormer"
+  description: "Brainstorm: {task.title}"
+  prompt: [Fill template from agents/templates/brainstorm-prompt.md]
+```
+
+Template variables: `{TASK_ID}`, `{TASK_TITLE}`, `{TASK_TYPE}` (the ohno task's `task_type`), `{TASK_DESCRIPTION}`, `{ACCEPTANCE_CRITERIA}`, `{TRIGGER_REASON}` (which trigger condition fired the gate, e.g. "Short description" or "No acceptance criteria"), `{WORKING_DIRECTORY}`.
+
 ### Processing Result
 
-- **Refined**: Update ohno with refined description/AC, proceed to the design review gate
-- **Needs Input**: supervised / semi-auto — PAUSE for human to answer brainstormer's questions; auto / unattended — log the open questions as assumptions (`add_task_activity`) and proceed with the brainstormer's best judgment. Never pause in auto/unattended.
+- **Refined**: Update ohno with the refined requirements, log it, and proceed to the design review gate:
+
+  ```
+  update_task(task_id, {
+    description: refined_description,
+    acceptance_criteria: proposed_criteria
+  })
+  add_task_activity(task_id, "note", "Brainstorm: Refined requirements")
+  ```
+
+- **Needs Input**: supervised / semi-auto — PAUSE for human to answer brainstormer's questions; auto / unattended — log the open questions as assumptions (`add_task_activity(task_id, "decision", "Auto-resolved open questions as assumptions (auto/unattended mode): {questions}")`) and proceed with the brainstormer's best judgment. Never pause in auto/unattended.
 
 ## Step 3: Design Review Gate (Conditional)
 
 Before dispatching the implementer, evaluate if the task needs design review.
 
-**Agent**: `yokay-design-reviewer` | **Template**: `agents/templates/design-review-prompt.md`
+**Agent**: `pokayokay:yokay-design-reviewer` | **Template**: `agents/templates/design-review-prompt.md`
 
 ### Skip Conditions
 

--- a/plugins/pokayokay/skills/work-session/references/error-recovery.md
+++ b/plugins/pokayokay/skills/work-session/references/error-recovery.md
@@ -1,5 +1,42 @@
 # Error Recovery
 
+Recovery playbook for coordinator-level failures during a work session.
+
+## Dispatch Failures
+
+A subagent dispatch that errors or times out, returns an empty or verdict-less
+report, returns only questions, or claims success without a commit is handled
+by the Dispatch Failure Protocol in [dispatch-errors.md](dispatch-errors.md).
+Hard rule: a task NEVER remains `in_progress` after its dispatch concludes —
+it ends the cycle `done`, `blocked`, or back to `todo`.
+
+## Handoff Store Failures
+
+Implementer and fixer agents wrap their `set-handoff` CLI call in a failure
+guard: when the store write fails, the agent reports `HANDOFF STORE FAILED`
+and includes the full handoff details in its inline report instead. Use that
+inline report as the handoff source when filling review templates (instead of
+`get_task_handoff`), and log the store failure via `add_task_activity`.
+
+## Unparseable Review Verdict
+
+Reviewers must end with a terminal `VERDICT: PASS | FAIL | BLOCKED` line. When
+a review report has no such line (bridge.py surfaces a "could not be parsed"
+warning), do NOT infer the verdict from prose. Re-dispatch the reviewer ONCE
+per dispatch-failure class (b) — instructing it to end with the required
+`VERDICT:` line — then `set_blocker` the task if the report is still
+unparseable.
+
+## Chain-State Desync
+
+When `.pokayokay/pokayokay-chain-state.json` disagrees with ohno (stale counts
+after a crash, tasks listed in `failed_tasks` that are actually done):
+
+1. Treat ohno as the source of truth for task status
+2. Re-derive `failed_tasks` / `conflict_tasks` from `get_blocked_tasks` and session context
+3. Rewrite the chain-state file with corrected values before session end
+4. Stale sessions with `in_progress` tasks are recovered automatically by `hooks/actions/recover.sh` (WIP saved, crash note folded in) — do not re-run recovery manually
+
 ## Build Failures
 
 ```markdown
@@ -13,7 +50,7 @@
 2. Identify breaking change
 3. Fix type error
 4. Verify build passes
-5. Block task if needed: `ohno block <id> "Build failure"`
+5. Block task if needed: `npx @stevestomp/ohno-cli block <id> "Build failure"`
 6. Continue or escalate
 
 Proceeding with recovery...
@@ -23,11 +60,11 @@ Proceeding with recovery...
 
 ```bash
 # Block a task
-ohno block task-abc123 "Waiting for API spec"
+npx @stevestomp/ohno-cli block task-abc123 "Waiting for API spec"
 
 # View blocked tasks
-ohno tasks --status blocked
+npx @stevestomp/ohno-cli tasks --status blocked
 
 # Resolve blocker
-ohno unblock task-abc123
+npx @stevestomp/ohno-cli unblock task-abc123
 ```

--- a/plugins/pokayokay/skills/work-session/references/kaizen-review-failures.md
+++ b/plugins/pokayokay/skills/work-session/references/kaizen-review-failures.md
@@ -1,0 +1,165 @@
+# Kaizen Review-Failure Handling
+
+How the coordinator acts on the post-review-fail hook's kaizen outcome after a
+spec or quality review fails. `/work` (work.md "Review Failure Hook
+Integration") summarizes this flow and points here.
+
+## Hook Invocation (Automatic)
+
+When either spec or quality review fails, `bridge.py` detects the FAIL in the
+reviewer's Task output (PostToolUse) and invokes the post-review-fail hook
+**automatically**. Do NOT run `hooks/post-review-fail.sh` yourself — manual
+invocation risks double execution (duplicate kaizen fix-task suggestions),
+and in consuming projects the script may not exist at all.
+
+The bridge resolves the hook from the *project's* `hooks/post-review-fail.sh`
+(so projects can supply their own kaizen wiring). When the script is absent,
+the failure is still tracked locally (recurring-failure detection +
+graduate-rules) and the outcome is `kaizen_action: LOGGED`.
+
+The hook result surfaces as hook output context after the reviewer's Task
+call, with a `kaizen_action` of AUTO, SUGGEST, or LOGGED (plus `fix_task`
+details when available). The coordinator's only job is to act on that
+outcome.
+
+## 1. AUTO Action (High Confidence)
+
+Hook detects a well-known failure pattern and auto-creates a fix task.
+
+```json
+{
+  "action": "AUTO",
+  "fix_task": {
+    "title": "Fix: Missing error handling in API endpoint",
+    "description": "Review failed due to missing error handling...",
+    "type": "bug",
+    "estimate": 2
+  }
+}
+```
+
+Coordinator behavior:
+1. Create fix task in ohno:
+   ```bash
+   npx @stevestomp/ohno-cli create "${fix_task.title}" \
+     -t ${fix_task.type} \
+     --description "${fix_task.description}" \
+     -e ${fix_task.estimate} \
+     --source "kaizen-fix"
+   ```
+2. Block current task on the fix task:
+   ```bash
+   npx @stevestomp/ohno-cli dep add <current-task-id> <fix-task-id>
+   npx @stevestomp/ohno-cli block <current-task-id> "Blocked by fix task ${fix_task_id}"
+   ```
+3. Log activity:
+   ```bash
+   add_task_activity(task_id, "note", "Review failed, fix task auto-created: ${fix_task_id}")
+   ```
+4. Get next task and continue work loop
+
+## 2. SUGGEST Action (Medium Confidence)
+
+Hook has a suggestion but needs user confirmation.
+
+```json
+{
+  "action": "SUGGEST",
+  "fix_task": {
+    "title": "Fix: Improve test coverage for edge cases",
+    "description": "Review suggests adding tests for...",
+    "type": "test",
+    "estimate": 3
+  },
+  "confidence": "medium"
+}
+```
+
+Coordinator behavior (mode-aware, mirroring the NEEDS_DISCUSSION split in the
+Design Review Gate, work.md Step 3.7):
+
+**supervised / semi-auto:**
+1. Present suggestion to user:
+   ```markdown
+   Review failed. Suggested fix task:
+   - Title: ${fix_task.title}
+   - Type: ${fix_task.type}
+   - Estimate: ${fix_task.estimate}h
+   - Description: ${fix_task.description}
+
+   Create fix task? (yes/no/customize)
+   ```
+2. Handle user response:
+   - **yes**: Create fix task, block current task, get next task
+   - **no**: Continue with existing re-dispatch behavior (max 3 cycles)
+   - **customize**: Let user modify fix_task details, then create
+
+**auto / unattended:**
+
+Do NOT prompt. Log the suggestion and auto-resolve:
+1. Log: `add_task_activity(task_id, "note", "Review-fail SUGGEST auto-resolved (auto/unattended): ${fix_task.title}")`
+2. If review cycles remain (<3 used): continue with the existing re-dispatch behavior (the "no" path)
+3. If this failure consumed the final review cycle: create the suggested fix task, block the current task on it, and get the next task (the "yes" path) — the suggestion is not lost
+
+## 3. LOGGED Action (Low Confidence)
+
+Hook cannot confidently suggest a fix task, only logs the failure.
+
+```json
+{
+  "action": "LOGGED",
+  "message": "Failure logged to kaizen database"
+}
+```
+
+Coordinator behavior:
+1. Log activity:
+   ```bash
+   add_task_activity(task_id, "note", "Review failed: ${FAILURE_DETAILS}")
+   ```
+2. Continue with existing re-dispatch behavior (max 3 cycles)
+
+## Hook Integration Flow
+
+```
+Review FAIL
+     │
+     ▼
+┌─────────────────┐
+│ bridge.py runs  │
+│ post-review-fail│
+│ (automatic)     │
+└────────┬────────┘
+         │
+         ▼
+ Read kaizen_action
+ from hook output
+         │
+    ┌────┴─────┬─────────────┐
+    │          │             │
+    ▼          ▼             ▼
+┌──────┐  ┌─────────┐  ┌──────────┐
+│ AUTO │  │ SUGGEST │  │ LOGGED   │
+└───┬──┘  └────┬────┘  └─────┬────┘
+    │          │              │
+    ▼          ▼              │
+┌──────────┐  ┌──────────┐   │
+│ Create   │  │ Prompt   │   │
+│ fix task │  │ user     │   │
+└─────┬────┘  └────┬─────┘   │
+      │            │         │
+      │       ┌────┴─────┐   │
+      │       │          │   │
+      │      yes        no   │
+      │       │          │   │
+      ▼       ▼          ▼   ▼
+┌─────────────────────────────┐
+│ Block current task          │
+│ Get next task               │
+└─────────────────────────────┘
+                  OR
+┌─────────────────────────────┐
+│ Re-dispatch implementer     │
+│ (existing behavior)         │
+└─────────────────────────────┘
+```

--- a/plugins/pokayokay/skills/work-session/references/parallel-execution.md
+++ b/plugins/pokayokay/skills/work-session/references/parallel-execution.md
@@ -45,10 +45,26 @@ after batches complete cleanly.
 
 ## Dependency Handling
 
-The ohno `blockedBy` graph is the safety mechanism:
+The ohno `blockedBy` graph is the primary safety mechanism:
 - Tasks with unmet dependencies are not dispatched
 - If Task B depends on Task A, B waits for A to complete
-- No additional conflict detection - trust the dependency graph
+
+## Conflict Detection (Two-Tier)
+
+On top of the dependency graph, the coordinator runs two conflict checks over
+every queued batch and UNIONS their results (work.md "File conflict check") —
+a task pair flagged by EITHER check is serialized:
+
+1. **Structured check — `Packages:` trailer**: `/plan` appends a final
+   machine-parsed description line in the exact form
+   `Packages: <comma-separated packages_touched>` (e.g.
+   `Packages: @sakeba/api, apps/web`) when the planner provides
+   `packages_touched`. Two tasks declaring a shared package never run in the
+   same batch — the later task is deferred to the next batch.
+2. **Heuristic check — regex over title+description**: extracts likely file
+   paths, module directories, and table references. It runs on every queued
+   task, and is the ONLY signal for tasks without a `Packages:` line (created
+   via `/quick`, `/fix`, `/hotfix`, or plans predating the trailer).
 
 ## Work Loop with Hooks (Parallel)
 

--- a/plugins/pokayokay/skills/work-session/references/review-pipeline.md
+++ b/plugins/pokayokay/skills/work-session/references/review-pipeline.md
@@ -10,7 +10,7 @@ Fill EVERY placeholder in both templates — never dispatch a prompt containing 
 
 ## Stage 1: Spec Compliance Review
 
-**Agent**: `yokay-spec-reviewer` | **Template**: `agents/templates/spec-review-prompt.md`
+**Agent**: `pokayokay:yokay-spec-reviewer` | **Template**: `agents/templates/spec-review-prompt.md`
 
 | Variable | Source |
 |----------|--------|
@@ -21,25 +21,29 @@ Fill EVERY placeholder in both templates — never dispatch a prompt containing 
 | `{IMPLEMENTATION_SUMMARY}` | Implementer's ohno handoff via `get_task_handoff(task_id)` — the inline report is minimal |
 | `{FILES_CHANGED}` | Implementer handoff / `git diff --name-only` |
 | `{COMMIT_INFO}` | Implementer's commit (hash + message) |
-| `{COMMIT_HASH}` | Bare commit hash — used in the templates' `git diff` verification commands |
+| `{BASE_COMMIT}` | Recorded by coordinator at implementer dispatch (work.md Step 4); primary diff baseline, includes working tree |
 | `{WORKING_DIRECTORY}` | Task's worktree path or project root |
 
-- **FAIL**: Re-dispatch implementer with spec issues. Skip quality review.
-- **PASS**: Proceed to Stage 2.
+The coordinator branches on the reviewer's final `VERDICT:` line (`VERDICT: PASS | FAIL | BLOCKED`), not on prose or evidence rows:
+
+- **VERDICT: FAIL**: Re-dispatch implementer with spec issues. Skip quality review.
+- **VERDICT: PASS**: Proceed to Stage 2.
+- **VERDICT: BLOCKED**: Reviewer could not review (missing input). Does not consume a review cycle; fix the named input, re-dispatch the reviewer once, then `set_blocker` if still BLOCKED.
 
 ## Stage 2: Code Quality Review
 
 Only runs if spec review passes.
 
-**Agent**: `yokay-quality-reviewer` | **Template**: `agents/templates/quality-review-prompt.md`
+**Agent**: `pokayokay:yokay-quality-reviewer` | **Template**: `agents/templates/quality-review-prompt.md`
 
 | Variable | Source |
 |----------|--------|
 | `{TASK_ID}` | Original task |
 | `{TASK_TITLE}` | Original task |
+| `{ACCEPTANCE_CRITERIA}` | Original task (post-brainstorm) — input for the Test-AC Mapping check |
 | `{FILES_CHANGED}` | Implementer handoff / `git diff --name-only` |
 | `{COMMIT_INFO}` | Implementer's commit (hash + message) |
-| `{COMMIT_HASH}` | Bare commit hash |
+| `{BASE_COMMIT}` | Recorded by coordinator at implementer dispatch (work.md Step 4); primary diff baseline, includes working tree |
 | `{APPROACH}` | Design review output (stored at the design review gate), or `None — design review was skipped` |
 | `{WORKING_DIRECTORY}` | Task's worktree path or project root |
 
@@ -47,22 +51,29 @@ The quality reviewer uses `{APPROACH}` for its design-compliance post-check;
 when it is `None`, the reviewer marks design compliance `N/A` (this covers
 `/fix` and `/hotfix`, which deliberately run no design review).
 
-- **FAIL**: Re-dispatch implementer with quality issues.
-- **PASS**: Proceed to task completion.
+Branch on the final `VERDICT:` line here too:
+
+- **VERDICT: FAIL**: Re-dispatch implementer with quality issues.
+- **VERDICT: PASS**: Proceed to task completion.
+- **VERDICT: BLOCKED**: Same handling as Stage 1 — no review cycle consumed; fix input, re-dispatch reviewer once, then `set_blocker`.
 
 ## Review Flow
 
+Each review returns a terminal `VERDICT: PASS | FAIL | BLOCKED` line; the coordinator branches on it.
+
 ```
-IMPLEMENT ──► SPEC REVIEW ──FAIL──► RE-IMPLEMENT (with spec issues)
-                  │                       │
-                 PASS                     │
+IMPLEMENT ──► SPEC REVIEW ──VERDICT: FAIL──► RE-IMPLEMENT (with spec issues)
+                  │      └──VERDICT: BLOCKED──► fix input, re-review once
+                  │
+          VERDICT: PASS                   │
                   │                       │
                   ▼                       │
              QUALITY REVIEW ◄─────────────┘
                   │
-                  │──FAIL──► RE-IMPLEMENT (with quality issues)
+                  │──VERDICT: FAIL──► RE-IMPLEMENT (with quality issues)
+                  │──VERDICT: BLOCKED──► fix input, re-review once
                   │
-                 PASS
+          VERDICT: PASS
                   │
                   ▼
              COMPLETE TASK
@@ -73,12 +84,14 @@ the redesign cycle in [dispatch-preparation.md](dispatch-preparation.md).
 
 ## Review Loop Control
 
-Maximum review cycles: 3
+Maximum review cycles: 3. BLOCKED verdicts do not count against the cycle budget.
 
-After 3 failed review cycles:
-1. Log escalation to ohno via `add_task_activity`
-2. Block task with `set_blocker`
-3. PAUSE for human intervention
+After 3 failed review cycles, escalate per mode:
+
+- **supervised / semi-auto**: Log escalation via `add_task_activity`, block the task with `set_blocker`, and PAUSE — present the review history and options to the human. Also pause when a reviewer returns BLOCKED twice for the same task.
+- **auto / unattended**: Do NOT pause. Call `mcp__ohno__set_needs_rework(task_id, reason)` (or `set_blocker` when rework does not apply), log via `add_task_activity`, and continue to the next task.
+
+**Hard rule**: A task whose review did not end in PASS is NEVER marked done.
 
 ## ohno Activity Logging
 

--- a/plugins/pokayokay/skills/work-session/references/skill-routing.md
+++ b/plugins/pokayokay/skills/work-session/references/skill-routing.md
@@ -33,12 +33,10 @@ ohno task types describe the **nature of work**, not the layer. Route by keyword
 | "API test", "contract test", "integration test", "mock" | testing-strategy |
 | "refactor", "architecture", "structure", "module", "boundary" | architecture-review |
 | "SDK", "library", "package", "npm publish", "extract" | sdk-development |
-| "Figma", "plugin", "design tool" | figma-plugin |
 | "security", "audit", "vulnerability", "CVE", "OWASP", "injection" | security-audit |
-| "performance", "slow", "optimize", "bundle", "cache", "latency" | performance-optimization |
 | "database", "schema", "migration", "query", "index" | database-design |
 | "error", "exception", "error handling", "retry", "fallback" | error-handling |
-| "logging", "metrics", "tracing", "monitoring", "alerting" | observability |
+| "performance", "slow", "latency", "logging", "metrics", "tracing", "monitoring", "alerting" | observability |
 | "CI", "CD", "pipeline", "deploy", "GitHub Actions", "workflow" | ci-cd |
 | "README", "docs", "ADR", "documentation", "user guide" | documentation |
 | "PRD", "requirements", "feature spec", "implementation plan" | planning |

--- a/plugins/pokayokay/skills/worktrees/SKILL.md
+++ b/plugins/pokayokay/skills/worktrees/SKILL.md
@@ -17,7 +17,7 @@ Guide for managing git worktrees in pokayokay.
 | spike | Worktree | --in-place |
 | chore | In-place | --worktree |
 | docs | In-place | --worktree |
-| test | Inherits | explicit flag |
+| test | Inherits the story worktree (tasks in the same story share it) | explicit flag |
 
 ## Key Principles
 

--- a/plugins/pokayokay/tests/dispatch-id-format.test.sh
+++ b/plugins/pokayokay/tests/dispatch-id-format.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Doc-contract test: every dispatch ID a coordinator can copy from the docs
+# must be plugin-qualified (pokayokay:yokay-<name>), never a bare yokay- label.
+# Scans commands, agent templates, SKILL.md files, and skill references.
+# File-path references like agents/yokay-<name>.md are legitimate and ignored.
+
+set -euo pipefail
+
+echo "Testing dispatch ID format in documentation..."
+
+DOC_FILES=(
+  plugins/pokayokay/commands/*.md
+  plugins/pokayokay/agents/templates/*.md
+  plugins/pokayokay/skills/*/SKILL.md
+  plugins/pokayokay/skills/*/references/*.md
+)
+
+# Test 1: no legacy "Task tool (yokay-..." dispatch shorthand anywhere
+echo "Test 1: No 'Task tool (yokay-' shorthand"
+if grep -n "Task tool (yokay-" "${DOC_FILES[@]}" ; then
+  echo "  FAIL: legacy 'Task tool (yokay-' shorthand found (see matches above)"
+  exit 1
+else
+  echo "  PASS: No legacy dispatch shorthand"
+fi
+
+# Test 2: every subagent_type line naming a yokay- agent is plugin-qualified.
+# Note: 'pokayokay' itself contains 'yokay', so check for lines with 'yokay-'
+# that lack the qualified 'pokayokay:yokay-' form.
+echo "Test 2: subagent_type lines are plugin-qualified"
+if grep -rn "subagent_type" "${DOC_FILES[@]}" | grep "yokay-" | grep -v "pokayokay:yokay-" ; then
+  echo "  FAIL: unqualified subagent_type dispatch ID found (see matches above)"
+  exit 1
+else
+  echo "  PASS: All subagent_type dispatch IDs qualified"
+fi
+
+# Test 3: no '**Agent**:' gate label with a bare yokay- ID (backticks optional)
+echo "Test 3: Agent gate labels are plugin-qualified"
+if grep -rnE '\*\*Agent\*\*:.*`?yokay-' "${DOC_FILES[@]}" | grep -v "pokayokay:yokay-" ; then
+  echo "  FAIL: bare '**Agent**: yokay-...' label found (see matches above)"
+  exit 1
+else
+  echo "  PASS: All Agent gate labels qualified"
+fi
+
+echo ""
+echo "All dispatch ID format tests passed!"

--- a/plugins/pokayokay/tests/parallel-mode.test.sh
+++ b/plugins/pokayokay/tests/parallel-mode.test.sh
@@ -63,5 +63,54 @@ else
   exit 1
 fi
 
+# Test 7: Structured conflict check (Packages trailer) documented before heuristic
+echo "Test 7: Structured conflict check before heuristic"
+STRUCTURED_LINE=$(grep -n "Structured conflict check" "$WORK_FILE" | head -1 | cut -d: -f1)
+HEURISTIC_LINE=$(grep -n "detect_file_conflicts" "$WORK_FILE" | head -1 | cut -d: -f1)
+
+if [[ -z "$STRUCTURED_LINE" ]]; then
+  echo "  FAIL: 'Structured conflict check' not found in work.md"
+  exit 1
+fi
+if [[ -z "$HEURISTIC_LINE" ]]; then
+  echo "  FAIL: detect_file_conflicts heuristic not found in work.md"
+  exit 1
+fi
+if [[ $STRUCTURED_LINE -lt $HEURISTIC_LINE ]]; then
+  echo "  PASS: Structured check documented before the regex heuristic"
+else
+  echo "  FAIL: Structured check (line $STRUCTURED_LINE) not before heuristic (line $HEURISTIC_LINE)"
+  exit 1
+fi
+
+# Test 8: Both checks unioned (heuristic still runs on tagged tasks)
+echo "Test 8: Structured + heuristic conflict sets unioned"
+if grep -q "detect_package_conflicts(queued_tasks) + detect_file_conflicts(queued_tasks)" "$WORK_FILE"; then
+  echo "  PASS: Conflict sets unioned"
+else
+  echo "  FAIL: Union of structured + heuristic conflict sets not found"
+  exit 1
+fi
+
+# Test 9: plan.md instructs the Packages: description trailer
+echo "Test 9: plan.md Packages: trailer instruction"
+PLAN_FILE="plugins/pokayokay/commands/plan.md"
+if grep -q "Packages: <comma-separated packages_touched>" "$PLAN_FILE"; then
+  echo "  PASS: Packages: trailer documented in plan.md"
+else
+  echo "  FAIL: Packages: trailer instruction not found in plan.md"
+  exit 1
+fi
+
+# Test 10: parallel-execution.md documents the two-tier conflict check
+echo "Test 10: Two-tier conflict detection in parallel-execution.md"
+PARALLEL_REF="plugins/pokayokay/skills/work-session/references/parallel-execution.md"
+if grep -q "Conflict Detection (Two-Tier)" "$PARALLEL_REF" && grep -q "Packages:" "$PARALLEL_REF"; then
+  echo "  PASS: Two-tier conflict detection documented"
+else
+  echo "  FAIL: Two-tier conflict detection not documented in parallel-execution.md"
+  exit 1
+fi
+
 echo ""
 echo "All parallel mode tests passed!"

--- a/plugins/pokayokay/tests/pre-commit-blocking.test.sh
+++ b/plugins/pokayokay/tests/pre-commit-blocking.test.sh
@@ -181,6 +181,19 @@ SIBLING_GLOB_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add
 assert_not_blocked "$SIBLING_GLOB_OUTPUT"
 echo "  PASS: glob under demo-other does not match the demo/ reference"
 
+echo "Test 5m: commit message mentioning a ref path does not false-block an unrelated add"
+# bridge.py neutralizes && -> spaces, so the pathspec region cannot rely on
+# separators. The message must NOT be scanned as a pathspec: `git add src.txt`
+# is unrelated to the oversized ref merely named in the commit message.
+echo "unrelated" > src.txt
+git add src.txt
+MSG_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add src.txt && git commit -m \"fix plugins/pokayokay/skills/demo/references/big-ref.md\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_not_blocked "$MSG_OUTPUT"
+echo "  PASS: ref path in the commit message does not gate an unrelated add"
+git rm -q --cached src.txt
+rm -f src.txt
+
 echo "Test 6: advisory failures (lint exit 1) do not block the commit"
 # Remove the violation entirely and stage a package.json whose lint fails.
 rm -f "$REF_DIR/big-ref.md"

--- a/plugins/pokayokay/tests/pre-commit-blocking.test.sh
+++ b/plugins/pokayokay/tests/pre-commit-blocking.test.sh
@@ -191,6 +191,15 @@ MSG_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add src.txt 
   python3 "$BRIDGE")
 assert_not_blocked "$MSG_OUTPUT"
 echo "  PASS: ref path in the commit message does not gate an unrelated add"
+
+echo "Test 5n: a later add/commit pair in a compound command is still gated"
+# `git add src.txt && git commit -m ok && git add <big-ref> && git commit -m ref`
+# — the oversized ref is staged by the SECOND add; every add segment must be
+# scanned, not just the first before the first commit.
+MULTI_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add src.txt && git commit -m ok && git add plugins/pokayokay/skills/demo/references/big-ref.md && git commit -m ref"},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_deny "$MULTI_OUTPUT"
+echo "  PASS: second git add in a compound command is gated"
 git rm -q --cached src.txt
 rm -f src.txt
 

--- a/plugins/pokayokay/tests/review-verdict-parsing.test.sh
+++ b/plugins/pokayokay/tests/review-verdict-parsing.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Validate bridge.py parses the reviewer verdict contract:
+# - terminal "VERDICT: PASS|FAIL|BLOCKED" line wins over substrings like
+#   "Result: PASS" in evidence rows
+# - BLOCKED is a non-verdict for kaizen (skip, never post-review-fail)
+# - missing VERDICT line falls back to the anchored review heading
+# - neither signal -> visible unparseable warning (fail closed), not "{}"
+
+set -euo pipefail
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf -- "$TEST_DIR"' EXIT
+
+BRIDGE="$(cd "$(dirname "$0")/.." && pwd)/hooks/actions/bridge.py"
+
+echo "Testing bridge review verdict parsing..."
+
+cd "$TEST_DIR"
+
+unset CLAUDE_PROJECT_DIR YOKAY_PROJECT_DIR CODEX_WORKSPACE_DIR 2>/dev/null || true
+
+# Mock npx so nothing shells out to the network
+MOCK_BIN="$TEST_DIR/bin"
+mkdir -p "$MOCK_BIN"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_BIN/npx"
+chmod +x "$MOCK_BIN/npx"
+export PATH="$MOCK_BIN:$PATH"
+
+# Project-root post-review-fail hook (resolved from the project dir by design)
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/post-review-fail.sh" << 'EOF'
+#!/usr/bin/env bash
+echo '{"action":"LOGGED","message":"from-mock-hook"}'
+EOF
+chmod +x "$TEST_DIR/hooks/post-review-fail.sh"
+
+export CURRENT_OHNO_TASK_ID="T-9"
+
+TRACKING="$TEST_DIR/.pokayokay/pokayokay-review-failures.json"
+
+echo "Test 1: terminal VERDICT: PASS is classified PASS (no failure hook)"
+cat > "$TEST_DIR/payload-pass.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"pokayokay:yokay-quality-reviewer","description":"Quality review for T-9"},"tool_response":{"content":[{"type":"text","text":"## Quality Review: PASS\n\n**Task**: T-9\n\nCode is well-structured and tested.\n\nVERDICT: PASS"}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-pass.json" 2>/dev/null)
+
+if [[ "$OUTPUT" == "{}" ]]; then
+  echo "  PASS: passing review skipped silently"
+else
+  echo "  FAIL: expected {} for VERDICT: PASS"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+echo "Test 2: VERDICT: BLOCKED skips kaizen FAIL routing entirely"
+cat > "$TEST_DIR/payload-blocked.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"pokayokay:yokay-quality-reviewer","description":"Quality review for T-9"},"tool_response":{"content":[{"type":"text","text":"## Quality Review: BLOCKED\n\n**Condition**: (b) no acceptance criteria in the dispatch prompt\n**Evidence**: The Acceptance Criteria section contains the literal placeholder\n**Needed from coordinator**: Fill ACCEPTANCE_CRITERIA and re-dispatch\n\nVERDICT: BLOCKED"}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-blocked.json" 2>/dev/null)
+
+if [[ "$OUTPUT" == "{}" ]] && [[ "$OUTPUT" != *"post-review-fail"* ]]; then
+  echo "  PASS: BLOCKED treated as non-verdict skip"
+else
+  echo "  FAIL: BLOCKED must not route to post-review-fail"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+if [[ ! -f "$TRACKING" ]]; then
+  echo "  PASS: BLOCKED did not write failure tracking"
+else
+  echo "  FAIL: BLOCKED must not be tracked as a review failure"
+  cat "$TRACKING"
+  exit 1
+fi
+
+echo "Test 3: FAIL report containing 'Result: PASS' evidence is classified FAIL"
+cat > "$TEST_DIR/payload-adversarial-fail.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"pokayokay:yokay-quality-reviewer","description":"Quality review for T-9"},"tool_response":{"content":[{"type":"text","text":"## Quality Review: FAIL\n\n**Task**: T-9\n\n### Verification Evidence\n\n- Command(s): npm test\n- Result: PASS, exit 0 (lint), but coverage checks were skipped\n\n### Issues\n\n| Issue | Severity | Detail |\n|-------|----------|--------|\n| Missing tests for MUST criterion | Major | src/api.ts:10 |\n\n### Required Fixes\n1. Add missing validation tests\n\nVERDICT: FAIL"}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-adversarial-fail.json" 2>/dev/null)
+
+if [[ "$OUTPUT" == *"post-review-fail"* ]]; then
+  echo "  PASS: terminal VERDICT: FAIL overrode 'Result: PASS' substring"
+else
+  echo "  FAIL: expected post-review-fail despite 'Result: PASS' evidence line"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+if [[ -f "$TRACKING" ]]; then
+  echo "  PASS: failure tracked for graduation"
+else
+  echo "  FAIL: expected failure tracking file at $TRACKING"
+  exit 1
+fi
+
+echo "Test 4: no VERDICT line falls back to the anchored review heading"
+cat > "$TEST_DIR/payload-heading-fallback.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"pokayokay:yokay-quality-reviewer","description":"Quality review for T-9"},"tool_response":{"content":[{"type":"text","text":"## Quality Review: FAIL\n\n- Result: PASS, exit 0 for lint\n- No tests were added for the new endpoint"}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-heading-fallback.json" 2>/dev/null)
+
+if [[ "$OUTPUT" == *"post-review-fail"* ]]; then
+  echo "  PASS: heading fallback classified FAIL (FAIL precedence over substrings)"
+else
+  echo "  FAIL: expected post-review-fail via heading fallback"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+echo "Test 5: unparseable reviewer output fails closed with a visible warning"
+cat > "$TEST_DIR/payload-gibberish.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"pokayokay:yokay-quality-reviewer","description":"Quality review for T-9"},"tool_response":{"content":[{"type":"text","text":"The reviewer wandered off and wrote a poem about code quality instead."}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-gibberish.json" 2>/dev/null)
+
+if [[ "$OUTPUT" != "{}" ]] && [[ "$OUTPUT" == *"could not be parsed"* ]]; then
+  echo "  PASS: unparseable warning surfaced in additionalContext"
+else
+  echo "  FAIL: expected visible unparseable warning, not silent skip"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+if [[ "$OUTPUT" != *"post-review-fail"* ]]; then
+  echo "  PASS: unparseable output did not invoke the failure hook directly"
+else
+  echo "  FAIL: unparseable path must instruct re-dispatch, not run post-review-fail"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+echo "Test 6: description-only match keeps the silent skip on unparseable output"
+cat > "$TEST_DIR/payload-description-only.json" << 'EOF'
+{"tool_name":"Task","tool_input":{"subagent_type":"general-purpose","description":"Quality review notes cleanup"},"tool_response":{"content":[{"type":"text","text":"Tidied up the notes file."}]},"hook_event_name":"PostToolUse"}
+EOF
+OUTPUT=$(python3 "$BRIDGE" < "$TEST_DIR/payload-description-only.json" 2>/dev/null)
+
+if [[ "$OUTPUT" == "{}" ]]; then
+  echo "  PASS: non-reviewer Task with review-ish description skipped silently"
+else
+  echo "  FAIL: expected {} for description-only match"
+  echo "  Output: $OUTPUT"
+  exit 1
+fi
+
+echo ""
+echo "All review verdict parsing tests passed!"

--- a/plugins/pokayokay/tests/work-structure.test.sh
+++ b/plugins/pokayokay/tests/work-structure.test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Doc-structure test: work.md's headless/chain-state, kaizen review-failure,
+# and Brainstorm Gate details live in skill references (progressive
+# disclosure). work.md keeps a summary + ${CLAUDE_PLUGIN_ROOT} pointer at each
+# site; the extracted bodies must not reappear inline.
+
+set -euo pipefail
+
+echo "Testing work.md structure (progressive disclosure)..."
+
+WORK_FILE="plugins/pokayokay/commands/work.md"
+REF_DIR="plugins/pokayokay/skills/work-session/references"
+
+# Test 1: extracted reference files exist
+echo "Test 1: Extracted reference files exist"
+for ref in chain-state.md kaizen-review-failures.md dispatch-preparation.md; do
+  if [[ ! -f "$REF_DIR/$ref" ]]; then
+    echo "  FAIL: $REF_DIR/$ref not found"
+    exit 1
+  fi
+done
+echo "  PASS: chain-state.md, kaizen-review-failures.md, dispatch-preparation.md exist"
+
+# Test 2: work.md points to chain-state.md via CLAUDE_PLUGIN_ROOT
+echo "Test 2: chain-state.md pointer in work.md"
+if grep -qF 'CLAUDE_PLUGIN_ROOT}/skills/work-session/references/chain-state.md' "$WORK_FILE"; then
+  echo "  PASS: chain-state pointer present"
+else
+  echo "  FAIL: chain-state pointer missing"
+  exit 1
+fi
+
+# Test 3: work.md points to kaizen-review-failures.md via CLAUDE_PLUGIN_ROOT
+echo "Test 3: kaizen-review-failures.md pointer in work.md"
+if grep -qF 'CLAUDE_PLUGIN_ROOT}/skills/work-session/references/kaizen-review-failures.md' "$WORK_FILE"; then
+  echo "  PASS: kaizen pointer present"
+else
+  echo "  FAIL: kaizen pointer missing"
+  exit 1
+fi
+
+# Test 4: work.md points to dispatch-preparation.md (Brainstorm Gate source)
+echo "Test 4: dispatch-preparation.md pointer in work.md"
+if grep -qF 'CLAUDE_PLUGIN_ROOT}/skills/work-session/references/dispatch-preparation.md' "$WORK_FILE"; then
+  echo "  PASS: dispatch-preparation pointer present"
+else
+  echo "  FAIL: dispatch-preparation pointer missing"
+  exit 1
+fi
+
+# Test 5: extracted chain-state bodies are gone from work.md
+echo "Test 5: Chain-state section bodies extracted"
+for marker in "#### Chain State Fields" "### Chain Reporting" "### Scope Filtering" "get_scoped_tasks"; do
+  if grep -qF "$marker" "$WORK_FILE"; then
+    echo "  FAIL: '$marker' still inline in work.md"
+    exit 1
+  fi
+done
+if grep -qF "Chain State Fields" "$REF_DIR/chain-state.md" && \
+   grep -qF "get_scoped_tasks" "$REF_DIR/chain-state.md"; then
+  echo "  PASS: Chain-state bodies live only in chain-state.md"
+else
+  echo "  FAIL: Extracted chain-state content not found in chain-state.md"
+  exit 1
+fi
+
+# Test 6: kaizen JSON contract block is gone from work.md
+echo "Test 6: Kaizen review-failure body extracted"
+if grep -qF '"action": "AUTO"' "$WORK_FILE"; then
+  echo "  FAIL: kaizen JSON contract still inline in work.md"
+  exit 1
+fi
+if grep -qF '"action": "AUTO"' "$REF_DIR/kaizen-review-failures.md"; then
+  echo "  PASS: Kaizen contract lives only in kaizen-review-failures.md"
+else
+  echo "  FAIL: Kaizen contract not found in kaizen-review-failures.md"
+  exit 1
+fi
+
+# Test 7: Brainstorm Gate body deduplicated (dispatch-preparation.md is source)
+echo "Test 7: Brainstorm Gate deduplicated"
+for marker in "def needs_brainstorm" "#### Brainstorm Flow"; do
+  if grep -qF "$marker" "$WORK_FILE"; then
+    echo "  FAIL: '$marker' still inline in work.md"
+    exit 1
+  fi
+done
+if grep -qF "AC Quality Check" "$REF_DIR/dispatch-preparation.md" && \
+   grep -qF "{TRIGGER_REASON}" "$REF_DIR/dispatch-preparation.md"; then
+  echo "  PASS: Brainstorm Gate details live in dispatch-preparation.md"
+else
+  echo "  FAIL: Brainstorm Gate details missing from dispatch-preparation.md"
+  exit 1
+fi
+
+# Test 8: load-bearing headings preserved in work.md
+echo "Test 8: Load-bearing headings preserved"
+for heading in "### 2. Route to Skill" "### 3. Brainstorm Gate (Conditional)" "### 4. Dispatch Implementer Subagent"; do
+  if ! grep -qF "$heading" "$WORK_FILE"; then
+    echo "  FAIL: heading '$heading' missing from work.md"
+    exit 1
+  fi
+done
+echo "  PASS: Route/Brainstorm/Dispatch headings intact"
+
+# Test 9: new reference files respect the 500-line cap
+echo "Test 9: Reference size cap"
+for ref in chain-state.md kaizen-review-failures.md; do
+  lines=$(wc -l < "$REF_DIR/$ref")
+  if [[ "$lines" -ge 500 ]]; then
+    echo "  FAIL: $ref is $lines lines (cap: 500)"
+    exit 1
+  fi
+done
+echo "  PASS: New references under 500 lines"
+
+echo ""
+echo "All work structure tests passed!"


### PR DESCRIPTION
## Summary

Follow-on work to the v0.26.0 audit (PRs #13, #14). Four commits authored after #13 merged never reached master, plus two fixes found while reconciling them.

### Committed work (authored post-#13)
- **`fix(review)`** — machine-parseable `VERDICT: PASS|FAIL|BLOCKED` terminal lines across the spec/quality review templates + agents, with a `BASE_COMMIT` baseline threaded from implementer dispatch through both reviewers so `git diff` in review is working-tree-inclusive. bridge.py's `handle_review_complete` now parses the last `VERDICT:` line (FAIL>BLOCKED>PASS fallback via headings), fixing silent drops of review-failure graduation. New `review-verdict-parsing.test.sh`.
- **`feat(work)`** — dispatch-failure protocol (4 failure classes), `packages_touched` conflict detection for parallel work, and a work.md split (churn extracted to `references/{chain-state,kaizen-review-failures,...}.md`, all under the 500-line cap). New `dispatch-id-format`, `work-structure`, `parallel-mode` tests.
- **`fix(skills)`** — purge pre-ohno task-store drift (`.claude/tasks.db`/`features.json` → ohno CLI/MCP), spike enum/path/time-box consistency, dead-route removal (performance-optimization / figma-plugin / accessibility-auditor).
- **`docs(changelog)`** — 0.26.0 entry.

### Fixes found during reconciliation
- **`fix(hooks)` ref-size false-block** — bridge.py neutralizes shell separators (`&& ; | ()`) to spaces before `check-ref-sizes.sh` sees the command, so #14's `[^;&|)]*` pathspec boundary was a no-op: the "add region" ran to end-of-string and swallowed the commit message, so `git add src.txt && git commit -m "fix .../big-ref.md"` was falsely blocked. Now bounds pathspec collection at the `commit` keyword. Regression test 5m. **This fixes a bug currently live on master from #14.**
- **`docs(spike)`** — canonicalize leftover `[name]` spike-path placeholders to `[date]-[slug]`.

## Review
Ran a 4-lens adversarial review (bridge-verdict correctness, work.md split coherence, skills purge integrity, changelog consistency) over the diff before opening: **verdict ship, zero must-fix**. The verdict parser was verified to exactly match the format templates emit; the split preserves every deleted heading in a resolvable reference; the purge leaves no dangling references.

## Test plan
- [x] `bash plugins/pokayokay/tests/run-tests.sh` — 35/35 (merged tree, macOS)
- [x] bridge.py `py_compile`, all shell `bash -n` clean
- [x] master merged in cleanly (zero conflicts); post-merge tree validated
- [ ] ubuntu CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)