### PR TITLE
fix(hooks): parse git subcommands in ref-size gate (commit-message re-entry)

### DIFF
--- a/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
+++ b/plugins/pokayokay/hooks/actions/check-ref-sizes.sh
@@ -52,13 +52,13 @@ if [ -z "$FILES" ]; then
       # `git add <pathspec>...`: gate reference files the add will stage.
       # bridge.py neutralizes shell separators (&& ; | ( )) to spaces before
       # we see the command, so the pathspec region cannot be bounded by them.
-      # Instead toggle collection at each `add`/`commit` boundary: tokens
-      # inside a `git add ...` segment are pathspecs; a `commit` ends the
-      # segment (its message must never be collected). This scans EVERY add
-      # segment in a compound command, not just the first, so a later
-      # `&& git add <oversized-ref>` cannot slip past the gate. The bare `git`
-      # word of a chained command and option flags are skipped. Candidates
-      # match by exact path, parent directory, or glob (references/*.md).
+      # Walk the token stream as a git command parser: `add`/`commit` are only
+      # honored as SUBCOMMANDS — the token following `git` past any global
+      # options — never as bare words. This scans EVERY `git add` segment in a
+      # compound command (so a later `&& git add <oversized-ref>` cannot slip
+      # past) while an `add`/`commit` word inside a commit MESSAGE (which is
+      # not a subcommand) can never start or restart pathspec collection.
+      # Candidates match by exact path, parent directory, or glob (refs/*.md).
       SCOPE="about-to-be-staged"
       CANDIDATES=$(list_working_tree_refs)
       NL=$'\n'
@@ -66,15 +66,26 @@ if [ -z "$FILES" ]; then
       # Extract pathspec tokens (tr avoids for-loop glob expansion).
       ALL_TOKENS=$(printf '%s' "$GIT_COMMAND" | tr ' \t' '\n\n')
       PATHSPECS=""
-      collecting=""
+      expect_subcmd=""   # just saw `git`, awaiting its subcommand
+      in_add=""          # currently inside a `git add` pathspec list
+      skip_next=""       # consume the argument of a -C/-c global option
       while IFS= read -r tok; do
         [ -n "$tok" ] || continue
-        if [ "$tok" = "add" ]; then collecting=1; continue; fi
-        if [ "$tok" = "commit" ]; then collecting=""; continue; fi
-        [ -n "$collecting" ] || continue
-        # Inside an add segment: skip the git word of a chained command and
-        # option flags; everything else is a pathspec.
-        [ "$tok" = "git" ] && continue
+        if [ -n "$skip_next" ]; then skip_next=""; continue; fi
+        if [ "$tok" = "git" ]; then
+          expect_subcmd=1; in_add=""; continue
+        fi
+        if [ -n "$expect_subcmd" ]; then
+          case "$tok" in
+            -C|-c) skip_next=1; continue ;;  # global option taking an argument
+            -*) continue ;;                   # other global option: keep waiting
+          esac
+          [ "$tok" = "add" ] && in_add=1 || in_add=""
+          expect_subcmd=""
+          continue
+        fi
+        [ -n "$in_add" ] || continue
+        # Inside the add pathspec list; skip option flags (e.g. --, -f).
         case "$tok" in -*) continue ;; esac
         PATHSPECS="${PATHSPECS}${PATHSPECS:+$NL}${tok}"
       done <<< "$ALL_TOKENS"

--- a/plugins/pokayokay/tests/pre-commit-blocking.test.sh
+++ b/plugins/pokayokay/tests/pre-commit-blocking.test.sh
@@ -203,6 +203,19 @@ echo "  PASS: second git add in a compound command is gated"
 git rm -q --cached src.txt
 rm -f src.txt
 
+echo "Test 5o: the word 'add' inside a commit message does not re-enter collection"
+# `git add src.txt && git commit -m "refactor and add plugins/.../big-ref.md"`
+# — `add`/`commit` are only honored as git subcommands, so the bare 'add' in
+# the message must NOT restart pathspec collection and pull in the ref path.
+echo "unrelated" > src.txt
+git add src.txt
+REENTER_OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"git add src.txt && git commit -m \"refactor and add plugins/pokayokay/skills/demo/references/big-ref.md\""},"hook_event_name":"PreToolUse"}' |
+  python3 "$BRIDGE")
+assert_not_blocked "$REENTER_OUTPUT"
+echo "  PASS: message word 'add' does not re-enter git-add collection"
+git rm -q --cached src.txt
+rm -f src.txt
+
 echo "Test 6: advisory failures (lint exit 1) do not block the commit"
 # Remove the violation entirely and stage a package.json whose lint fails.
 rm -f "$REF_DIR/big-ref.md"


### PR DESCRIPTION
## Summary

Follow-up to the ref-size gate fixes in #15. The multi-add scan toggled pathspec collection on any bare `add` token, so a commit message containing the word "add" re-entered collection and pulled the message's path in:

```
git add src.txt && git commit -m "refactor and add plugins/pokayokay/skills/demo/references/big-ref.md"
```

was falsely blocked even though the add is unrelated (bridge.py neutralizes `&&` to spaces, so the message tokens are in the same flat stream).

## Fix

Walk the token stream as a git command parser: `add`/`commit` are honored only as the **subcommand** following `git` (past global options, consuming `-C`/`-c` arguments), never as bare words. A commit message can no longer start or restart collection, while every real `git add` segment in a compound command is still scanned (the #15 multi-add fix is preserved).

## Test plan
- [x] New regression test 5o (message word `add` does not re-enter collection)
- [x] All prior cases hold: message-mention (5m), multi-pair (5n), glob/dot-relative/no-space (5h–5l), `-C` form
- [x] `bash plugins/pokayokay/tests/run-tests.sh` — 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)